### PR TITLE
fix(deploy): retire Vendure compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,10 @@
-# Coolify production compose — transitional v1 → v2.
-#
-# v2 apps serve the main domains; the v1 backend + storefront stay alive until
-# the v2 storefront ships (the public tenant shops depend on them).
+# Coolify production compose — Supabase v2 applications.
 #
 # Domain mapping (set in Coolify per service):
-#   web          -> dukarun.com         (v2 dashboard, port 80)
-#   super-admin  -> admin.dukarun.com   (v2 platform admin, port 80)
-#   storefront   -> store./jutik.dukarun.com  (v1, port 4202)
-#   backend      -> vendure.dukarun.com (v1 API, port 3000 — v1 storefront's backend)
+#   web          -> dukarun.com       (port 80)
+#   super-admin  -> admin.dukarun.com (port 80)
 #
-# SUPABASE_URL / SUPABASE_ANON_KEY must be set in the Coolify app env; the v1
-# services read their full config from the same env file (DB_*, REDIS_*, etc.).
+# SUPABASE_URL / SUPABASE_ANON_KEY must be set in the Coolify app env.
 
 services:
   web:
@@ -31,19 +25,4 @@ services:
         APP: super-admin
         SUPABASE_URL: ${SUPABASE_URL}
         SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
-    restart: unless-stopped
-
-  # --- v1 remnants (delete this block at final decommission) ---
-  storefront:
-    build:
-      context: .
-      dockerfile: archive/vendure/storefront/Dockerfile
-    env_file: .env
-    restart: unless-stopped
-
-  backend:
-    build:
-      context: .
-      dockerfile: archive/vendure/backend/Dockerfile
-    env_file: .env
     restart: unless-stopped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -51,8 +51,9 @@ show a 200 and the company row updating).
 
 ### 3. Storefront
 
-v2 `apps/storefront` is a placeholder; v1 keeps serving the tenant storefront
-domains until it ships. Do not redeploy storefront.
+The storefront is not part of the commissioned production compose. The v2
+`apps/storefront` remains a placeholder and the Vendure storefront/backend are
+retired from Coolify deployment.
 
 ## CI/CD
 


### PR DESCRIPTION
## What changed

- Remove the archived Vendure backend and storefront from the production Docker Compose stack.
- Keep only the commissioned Supabase `web` and `super-admin` applications.
- Update the deployment runbook to reflect the final production boundary.

## Why

Coolify correctly parsed the merged transitional compose and attempted to rebuild the archived Vendure storefront. Its dependency installation failed, blocking deployment of the v2 applications. The root compose must represent the commissioned system rather than the migration fallback.

## Validation

- `docker compose config --quiet` passes with production build arguments.
- Prettier and `git diff --check` pass.
- Existing production containers remained healthy after the failed pre-replacement build.