### PR TITLE
fix(deploy): persist marketing video

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ services:
         SITE_PUBLIC_URL: ${SITE_PUBLIC_URL:-https://dukarun.com}
         APP_PUBLIC_URL: ${APP_PUBLIC_URL:-https://app.dukarun.com}
         STOREFRONT_PUBLIC_URL: ${STOREFRONT_PUBLIC_URL:-https://store.dukarun.com}
+        MARKETING_VIDEO_BASE_URL: ${MARKETING_VIDEO_BASE_URL:-https://dukarun.com/media/video/product-overview}
         PUBLIC_DATA_MODE: live
+    volumes:
+      - /var/lib/dukarun/marketing-media:/usr/share/nginx/html/media:ro
     restart: unless-stopped
 
   web:


### PR DESCRIPTION
Restore the homepage product video in Coolify deployments.\n\n- pass the marketing video base URL into the site image build\n- bind-mount the existing host media directory read-only\n\nValidation: docker compose config --quiet