### PR TITLE
Add location-aware restocking intelligence and associated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ scripts/etl/out/
 docs/V1_V2_MIGRATION.md
 scripts/etl/REPORT.md
 scripts/etl/out/
+spikes/

--- a/apps/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.ts
@@ -19,6 +19,7 @@ import {
   DashboardDailySummary,
   DashboardLocationSummary,
   DashboardPeriodComparison,
+  DashboardProductSignals,
   DashboardTopVariant,
   ExpiringBatch,
   LowStockVariant,
@@ -35,6 +36,7 @@ import { CompanyPreferencesService } from '../../core/company-preferences.servic
 import { offlineDb, offlineScopeKey, type NamedSnapshot } from '../../pos/offline/offline-db';
 import { CacheJournalService, type CacheStreamHandler } from '../../core/cache-journal.service';
 import { PageActionsComponent } from '../../shared/ui/page-actions.component';
+import { selectDashboardSignalCandidates } from '../../reports/product-intelligence';
 
 type TopVariant = {
   variantId: string;
@@ -43,6 +45,11 @@ type TopVariant = {
   quantity: number;
   revenue: number;
   margin: number;
+};
+type ProductSignal = TopVariant & {
+  productId: string | null;
+  kind: 'restock' | 'margin' | 'movement';
+  stock: number | null;
 };
 type LowStockDisplay = LowStockVariant & {
   manufacturer_name: string | null;
@@ -412,10 +419,15 @@ type DashboardSection = 'sales' | 'attention';
                 class="flex flex-wrap items-end justify-between gap-2 border-b border-base-300 px-4 py-3"
               >
                 <div>
-                  <h2 class="section-title">Best margin</h2>
-                  <p class="type-caption mt-1">Top-performing variants over 7 days.</p>
+                  <h2 class="section-title">Product signals</h2>
+                  <p class="type-caption mt-1">Useful product movement over 7 days.</p>
                 </div>
-                <span class="type-caption">Top 5</span>
+                <a
+                  class="link text-xs"
+                  routerLink="/inventory/products"
+                  [queryParams]="{ stock: 'needs_restock' }"
+                  >View restock list</a
+                >
               </div>
 
               @if (initialLoading()) {
@@ -426,36 +438,50 @@ type DashboardSection = 'sales' | 'attention';
                   <span class="loading loading-spinner loading-sm"></span>
                   Loading products
                 </div>
-              } @else if (topVariants().length === 0) {
+              } @else if (productSignals().length === 0) {
                 <app-empty-state
                   [embedded]="true"
                   [compact]="true"
                   icon="heroCube"
-                  title="Nothing sold yet"
-                  description="Products rank here once completed sales have stock cost."
+                  title="No product signals yet"
+                  description="Product movement appears here after completed sales."
                 />
               } @else {
                 <div class="divide-y divide-base-200">
-                  @for (variant of topVariants(); track variant.variantId) {
-                    <div class="flex min-h-20 items-center gap-3 px-4 py-3">
+                  @for (signal of productSignals(); track signal.kind + signal.variantId) {
+                    <a
+                      class="flex min-h-20 items-center gap-3 px-4 py-3 hover:bg-base-200/40"
+                      [routerLink]="signal.productId ? '/inventory/products' : null"
+                      [queryParams]="{ product: signal.productId, variant: signal.variantId }"
+                    >
                       <div class="min-w-0 flex-1">
-                        <p class="truncate">
-                          <span class="font-medium">{{ variant.label }}</span>
-                          <span class="type-caption ml-2">#{{ $index + 1 }}</span>
-                        </p>
+                        <p class="truncate font-medium">{{ signal.label }}</p>
                         <p class="type-caption truncate">
-                          {{ variant.manufacturer }} · qty {{ quantity(variant.quantity) }}
+                          {{ signal.manufacturer }} · {{ quantity(signal.quantity) }} sold
+                          @if (signal.stock !== null) {
+                            · {{ quantity(signal.stock) }} in stock
+                          }
                         </p>
                       </div>
-                      <div
-                        class="shrink-0 text-right font-medium"
-                        [class.text-success]="variant.margin > 0"
-                        [class.text-error]="variant.margin < 0"
-                      >
-                        <p class="text-base-content"><app-money [amount]="variant.revenue" /></p>
-                        <p class="type-caption">margin <app-money [amount]="variant.margin" /></p>
+                      <div class="shrink-0 text-right">
+                        <p class="text-xs font-semibold uppercase text-base-content/70">
+                          {{ signalLabel(signal.kind) }}
+                        </p>
+                        @if (signal.kind === 'margin') {
+                          <p
+                            class="type-caption"
+                            [class.text-success]="signal.margin > 0"
+                            [class.text-error]="signal.margin < 0"
+                          >
+                            <app-money [amount]="signal.margin" /> margin
+                          </p>
+                        } @else if (signal.kind === 'movement') {
+                          <p class="type-caption"><app-money [amount]="signal.revenue" /> sales</p>
+                        } @else {
+                          <p class="type-caption">Needs attention</p>
+                        }
                       </div>
-                    </div>
+                    </a>
                   }
                 </div>
               }
@@ -624,6 +650,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   protected readonly summary = signal<DashboardDailySummary[]>([]);
   protected readonly topVariants = signal<TopVariant[]>([]);
+  protected readonly productSignals = signal<ProductSignal[]>([]);
   protected readonly lowStock = signal<LowStockDisplay[]>([]);
   protected readonly lowStockTotal = signal(0);
   protected readonly expiring = signal<ExpiringDisplay[]>([]);
@@ -904,7 +931,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.summary.set(sales.summary);
     this.locationRows.set(sales.locations);
     this.comparison.set(sales.comparison);
-    await this.computeTopVariants(sales.topVariants);
+    await this.computeProductPerformance(sales.topVariants, sales.productSignals);
     if (sales.refreshAfter) this.scheduleSnapshotRefresh(sales.refreshAfter);
     else this.clearSnapshotRefresh();
   }
@@ -967,13 +994,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     };
     this.catalogCacheHandler = {
       apply: async () => {
-        await this.refreshTopVariantLabels();
-        await this.loadReports(['attention']);
+        await this.loadReports(['sales', 'attention']);
         if (!this.lastLoadSucceeded) throw new Error('dashboard_refresh_failed');
       },
       reset: async () => {
-        await this.refreshTopVariantLabels();
-        await this.loadReports(['attention']);
+        await this.loadReports(['sales', 'attention']);
         return this.lastLoadSucceeded;
       },
     };
@@ -1016,6 +1041,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const value = cached.value as {
       summary: DashboardDailySummary[];
       topVariants: TopVariant[];
+      productSignals?: ProductSignal[];
       lowStock: LowStockDisplay[];
       lowStockTotal?: number;
       attentionLocationId?: string;
@@ -1025,6 +1051,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     };
     this.summary.set(value.summary);
     this.topVariants.set(value.topVariants);
+    this.productSignals.set(value.productSignals ?? []);
     if (value.attentionLocationId === this.locations.activeId()) {
       this.lowStock.set(value.lowStock);
       this.lowStockTotal.set(value.lowStockTotal ?? value.lowStock.length);
@@ -1049,6 +1076,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       value: {
         summary: this.summary(),
         topVariants: this.topVariants(),
+        productSignals: this.productSignals(),
         lowStock: this.lowStock(),
         lowStockTotal: this.lowStockTotal(),
         attentionLocationId: this.locations.activeId(),
@@ -1079,6 +1107,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private clearFinancials(): void {
     this.summary.set([]);
     this.topVariants.set([]);
+    this.productSignals.set([]);
     this.locationRows.set([]);
     this.comparison.set({
       current_revenue: 0,
@@ -1090,21 +1119,70 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  private async computeTopVariants(rows: DashboardTopVariant[]): Promise<void> {
-    const variants = await this.pos.variantsByIds(rows.map(row => row.variant_id));
+  private async computeProductPerformance(
+    rows: DashboardTopVariant[],
+    signals: DashboardProductSignals
+  ): Promise<void> {
+    const variantIds = [
+      ...new Set([
+        ...rows.map(row => row.variant_id),
+        ...signals.fastVariants.map(row => row.variant_id),
+        ...signals.restockRisks.map(row => row.variant_id),
+      ]),
+    ];
+    let variants: Variant[] = [];
+    try {
+      variants = await this.pos.variantsByIds(variantIds);
+    } catch {
+      // Snapshot totals remain useful when catalog metadata is temporarily unavailable.
+    }
     const byId = new Map(variants.map(variant => [variant.variant_id, variant]));
-    this.topVariants.set(
-      rows.map(row => ({
-        variantId: row.variant_id,
-        label: byId.has(row.variant_id)
-          ? variantLabel(byId.get(row.variant_id) as Variant)
-          : row.variant_id.slice(0, 8),
-        manufacturer: byId.get(row.variant_id)?.manufacturer_name || 'Manufacturer not set',
-        quantity: Number(row.quantity),
-        revenue: row.revenue,
-        margin: row.margin,
-      }))
-    );
+    const displayRow = (row: DashboardTopVariant): TopVariant => ({
+      variantId: row.variant_id,
+      label: byId.has(row.variant_id)
+        ? variantLabel(byId.get(row.variant_id) as Variant)
+        : row.variant_id.slice(0, 8),
+      manufacturer: byId.get(row.variant_id)?.manufacturer_name || 'Manufacturer not set',
+      quantity: Number(row.quantity),
+      revenue: row.revenue,
+      margin: row.margin,
+    });
+    const top = rows.map(displayRow);
+    this.topVariants.set(top);
+
+    const result = selectDashboardSignalCandidates(
+      rows,
+      signals,
+      variantId => byId.get(variantId)?.product_id ?? variantId
+    ).map(candidate => {
+      const variant = byId.get(candidate.row.variant_id);
+      if (candidate.kind === 'restock') {
+        return {
+          variantId: candidate.row.variant_id,
+          productId: variant?.product_id ?? null,
+          label: variant ? variantLabel(variant) : candidate.row.variant_id.slice(0, 8),
+          manufacturer: variant?.manufacturer_name || 'Manufacturer not set',
+          quantity: Number(candidate.row.quantity),
+          revenue: 0,
+          margin: 0,
+          kind: candidate.kind,
+          stock: Number(candidate.row.stock),
+        } satisfies ProductSignal;
+      }
+      return {
+        ...displayRow(candidate.row),
+        productId: variant?.product_id ?? null,
+        kind: candidate.kind,
+        stock: null,
+      } satisfies ProductSignal;
+    });
+    this.productSignals.set(result);
+  }
+
+  protected signalLabel(kind: ProductSignal['kind']): string {
+    if (kind === 'restock') return 'Restock risk';
+    if (kind === 'margin') return 'Margin leader';
+    return 'Fast mover';
   }
 
   /** Coalesce a burst of sale invalidations before asking for the shared snapshot. */
@@ -1157,25 +1235,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (this.snapshotRefreshTimer) clearTimeout(this.snapshotRefreshTimer);
     this.snapshotRefreshTimer = null;
     this.snapshotRefreshAt = 0;
-  }
-
-  private async refreshTopVariantLabels(): Promise<void> {
-    const current = this.topVariants();
-    if (current.length === 0) return;
-    const variants = await this.pos.variantsByIds(current.map(row => row.variantId));
-    const byId = new Map(variants.map(variant => [variant.variant_id, variant]));
-    this.topVariants.set(
-      current.map(row => {
-        const variant = byId.get(row.variantId);
-        return variant
-          ? {
-              ...row,
-              label: variantLabel(variant),
-              manufacturer: variant.manufacturer_name || 'Manufacturer not set',
-            }
-          : row;
-      })
-    );
   }
 
   protected quantity(value: number): string {

--- a/apps/web/src/app/reports/product-intelligence.ts
+++ b/apps/web/src/app/reports/product-intelligence.ts
@@ -1,0 +1,35 @@
+import type {
+  DashboardProductSignals,
+  DashboardRestockRisk,
+  DashboardTopVariant,
+} from './reports.service';
+
+export type DashboardSignalCandidate =
+  | { kind: 'restock'; row: DashboardRestockRisk }
+  | { kind: 'margin' | 'movement'; row: DashboardTopVariant };
+
+export function selectDashboardSignalCandidates(
+  marginRows: DashboardTopVariant[],
+  signals: DashboardProductSignals,
+  productKey: (variantId: string) => string = variantId => variantId
+): DashboardSignalCandidate[] {
+  const result: DashboardSignalCandidate[] = [];
+  const used = new Set<string>();
+  const restock = signals.restockRisks[0];
+  if (restock) {
+    result.push({ kind: 'restock', row: restock });
+    used.add(productKey(restock.variant_id));
+  }
+
+  const margin = marginRows[0];
+  if (margin && !used.has(productKey(margin.variant_id))) {
+    result.push({ kind: 'margin', row: margin });
+    used.add(productKey(margin.variant_id));
+  }
+
+  const movement = signals.fastVariants[0];
+  if (movement && !used.has(productKey(movement.variant_id))) {
+    result.push({ kind: 'movement', row: movement });
+  }
+  return result;
+}

--- a/apps/web/src/app/reports/product-intelligence.unit.spec.ts
+++ b/apps/web/src/app/reports/product-intelligence.unit.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { selectDashboardSignalCandidates } from './product-intelligence';
+import type { DashboardProductSignals, DashboardTopVariant } from './reports.service';
+
+const row = (variant_id: string, quantity = 1): DashboardTopVariant => ({
+  variant_id,
+  quantity,
+  revenue: quantity * 100,
+  cogs: quantity * 60,
+  margin: quantity * 40,
+});
+
+describe('product intelligence', () => {
+  it('deduplicates restock, margin, and movement candidates', () => {
+    const signals: DashboardProductSignals = {
+      restockRisks: [{ variant_id: 'a', quantity: 10, stock: 2, low_stock_threshold: 5 }],
+      fastVariants: [row('c', 8)],
+    };
+    const selected = selectDashboardSignalCandidates([row('b'), row('a')], signals);
+    expect(selected.map(item => `${item.kind}:${item.row.variant_id}`)).toEqual([
+      'restock:a',
+      'margin:b',
+      'movement:c',
+    ]);
+  });
+
+  it('drops duplicate leaders from different variants of the same product', () => {
+    const signals: DashboardProductSignals = {
+      restockRisks: [{ variant_id: 'a-small', quantity: 10, stock: 2, low_stock_threshold: 5 }],
+      fastVariants: [row('a-large', 10), row('c', 8)],
+    };
+    const products = new Map([
+      ['a-small', 'a'],
+      ['a-large', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+    ]);
+    const selected = selectDashboardSignalCandidates(
+      [row('a-large'), row('b')],
+      signals,
+      variantId => products.get(variantId) ?? variantId
+    );
+    expect(selected.map(item => `${item.kind}:${item.row.variant_id}`)).toEqual([
+      'restock:a-small',
+    ]);
+  });
+});

--- a/apps/web/src/app/reports/reports.component.ts
+++ b/apps/web/src/app/reports/reports.component.ts
@@ -12,18 +12,9 @@ import { FormFieldComponent } from '../shared/ui/form-field.component';
 import { IconComponent } from '../shared/ui/icon.component';
 import { MobileListComponent } from '../shared/ui/mobile-list.component';
 import { PageActionsComponent } from '../shared/ui/page-actions.component';
+import { RestockIntelligenceComponent } from './restock-intelligence.component';
 
 type Tab = 'sales' | 'products' | 'customers' | 'inventory';
-
-type ProductRow = {
-  variantId: string;
-  label: string;
-  manufacturer: string;
-  quantity: number;
-  revenue: number;
-  cogs: number;
-  margin: number;
-};
 
 type CustomerRow = {
   customerId: string;
@@ -55,6 +46,7 @@ type InventoryRow = {
     IconComponent,
     MobileListComponent,
     PageActionsComponent,
+    RestockIntelligenceComponent,
   ],
   template: `
     <app-page title="Reports" [wide]="true">
@@ -275,72 +267,7 @@ type InventoryRow = {
 
       <!-- Products tab -->
       @if (tab() === 'products') {
-        @if (!loading() && products().length === 0) {
-          <app-empty-state
-            [compact]="true"
-            icon="heroCube"
-            title="No product sales in this range"
-            description="Variants rank here by revenue once you sell."
-          />
-        } @else {
-          <app-mobile-list>
-            @for (p of products(); track p.variantId) {
-              <div mobileListRow class="flex min-h-20 items-center gap-3 p-3">
-                <div class="min-w-0 flex-1">
-                  <p class="truncate font-semibold">{{ p.label }}</p>
-                  <p class="type-caption mt-1 truncate">
-                    {{ p.manufacturer }} · qty {{ p.quantity }}
-                  </p>
-                </div>
-                <div class="shrink-0 text-right">
-                  <p class="font-semibold tabular-nums">{{ fmt(p.revenue) }}</p>
-                  <p
-                    class="type-caption tabular-nums"
-                    [class.text-success]="p.margin > 0"
-                    [class.text-error]="p.margin < 0"
-                  >
-                    margin {{ fmt(p.margin) }}
-                  </p>
-                </div>
-              </div>
-            }
-          </app-mobile-list>
-          <div class="hidden bg-base-100 lg:block lg:rounded-box">
-            <div class="hidden lg:block">
-              <table class="table table-sm">
-                <thead>
-                  <tr>
-                    <th>Variant</th>
-                    <th class="text-right">Qty</th>
-                    <th class="text-right">Revenue</th>
-                    <th class="text-right">COGS</th>
-                    <th class="text-right">Margin</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (p of products(); track p.variantId) {
-                    <tr>
-                      <td>
-                        <p class="text-sm font-medium">{{ p.label }}</p>
-                        <p class="type-caption">{{ p.manufacturer }}</p>
-                      </td>
-                      <td class="text-right">{{ p.quantity }}</td>
-                      <td class="text-right">{{ fmt(p.revenue) }}</td>
-                      <td class="text-right">{{ fmt(p.cogs) }}</td>
-                      <td
-                        class="text-right font-medium"
-                        [class.text-success]="p.margin > 0"
-                        [class.text-error]="p.margin < 0"
-                      >
-                        {{ fmt(p.margin) }}
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </div>
-          </div>
-        }
+        <app-restock-intelligence [since]="appliedFrom()" [until]="appliedTo()" />
       }
 
       <!-- Customers tab -->
@@ -493,11 +420,10 @@ export class ReportsComponent implements OnInit {
   protected readonly tab = signal<Tab>('sales');
   protected readonly from = new FormControl(this.daysAgoIso(29), { nonNullable: true });
   protected readonly to = new FormControl(this.todayIso(), { nonNullable: true });
-  private appliedFrom = this.from.value;
-  private appliedTo = this.to.value;
+  protected readonly appliedFrom = signal(this.from.value);
+  protected readonly appliedTo = signal(this.to.value);
 
   protected readonly summary = signal<DailySummary[]>([]);
-  protected readonly products = signal<ProductRow[]>([]);
   protected readonly customers = signal<CustomerRow[]>([]);
   protected readonly inventory = signal<InventoryRow[]>([]);
   protected readonly error = signal<string | null>(null);
@@ -505,7 +431,6 @@ export class ReportsComponent implements OnInit {
   protected readonly filtersOpen = signal(false);
   protected readonly page = signal(1);
   protected readonly pageSize = 15;
-
   protected readonly totalPages = computed(() =>
     Math.max(1, Math.ceil(this.summary().length / this.pageSize))
   );
@@ -551,15 +476,13 @@ export class ReportsComponent implements OnInit {
     try {
       const since = this.from.value;
       const until = this.to.value;
-      const [summary, productSales, customerStats, stock, catalog] = await Promise.all([
+      const [summary, customerStats, stock, catalog] = await Promise.all([
         this.reports.salesSummary(since, until),
-        this.reports.productSales(since, until),
         this.reports.customerStats(since, until),
         this.pos.productStock(),
         this.pos.fetchActiveVariants(),
       ]);
       this.summary.set(summary);
-      await this.aggregateProducts(productSales);
       await this.aggregateCustomers(customerStats);
       this.inventory.set(
         catalog
@@ -579,8 +502,8 @@ export class ReportsComponent implements OnInit {
           })
           .sort((a, b) => b.value - a.value)
       );
-      this.appliedFrom = since;
-      this.appliedTo = until;
+      this.appliedFrom.set(since);
+      this.appliedTo.set(until);
     } catch (err) {
       this.error.set(err instanceof Error ? err.message : 'Failed to load reports');
     } finally {
@@ -594,44 +517,13 @@ export class ReportsComponent implements OnInit {
   }
 
   protected cancelReportFilters(): void {
-    this.from.setValue(this.appliedFrom);
-    this.to.setValue(this.appliedTo);
+    this.from.setValue(this.appliedFrom());
+    this.to.setValue(this.appliedTo());
     this.filtersOpen.set(false);
   }
 
   protected setReportTab(event: Event): void {
     this.tab.set((event.target as HTMLSelectElement).value as Tab);
-  }
-
-  private async aggregateProducts(
-    rows: import('./reports.service').DailyProductSales[]
-  ): Promise<void> {
-    const byVariant = new Map<string, { quantity: number; revenue: number; cogs: number }>();
-    for (const r of rows) {
-      if (!r.variant_id) continue;
-      const acc = byVariant.get(r.variant_id) ?? { quantity: 0, revenue: 0, cogs: 0 };
-      acc.quantity += Number(r.quantity ?? 0);
-      acc.revenue += r.revenue ?? 0;
-      acc.cogs += r.cogs ?? 0;
-      byVariant.set(r.variant_id, acc);
-    }
-    const top = [...byVariant.entries()].sort((a, b) => b[1].revenue - a[1].revenue).slice(0, 20);
-    const variants = await this.pos.variantsByIds(top.map(([id]) => id));
-    const byId = new Map(variants.map(v => [v.variant_id, v]));
-    this.products.set(
-      top.map(([variantId, acc]) => {
-        const variant = byId.get(variantId);
-        return {
-          variantId,
-          label: variant ? variantLabel(variant) : variantId.slice(0, 8),
-          manufacturer: variant?.manufacturer_name || 'Manufacturer not set',
-          quantity: acc.quantity,
-          revenue: acc.revenue,
-          cogs: acc.cogs,
-          margin: acc.revenue - acc.cogs,
-        };
-      })
-    );
   }
 
   private async aggregateCustomers(

--- a/apps/web/src/app/reports/reports.service.ts
+++ b/apps/web/src/app/reports/reports.service.ts
@@ -26,12 +26,73 @@ export interface DashboardTopVariant {
   margin: number;
 }
 
+export interface DashboardRestockRisk {
+  variant_id: string;
+  quantity: number;
+  stock: number;
+  low_stock_threshold: number;
+}
+
+export interface DashboardProductSignals {
+  restockRisks: DashboardRestockRisk[];
+  fastVariants: DashboardTopVariant[];
+}
+
 export interface DashboardSalesSnapshot {
   summary: DashboardDailySummary[];
   topVariants: DashboardTopVariant[];
+  productSignals: DashboardProductSignals;
   locations: DashboardLocationSummary[];
   comparison: DashboardPeriodComparison;
   refreshAfter?: string;
+}
+
+export interface RestockTrendPoint {
+  day: string;
+  currentQuantity: number;
+  previousQuantity: number;
+  currentRevenue: number;
+  previousRevenue: number;
+}
+
+export interface RestockProductRow {
+  variantId: string;
+  productId: string;
+  productName: string;
+  variantName: string;
+  manufacturerId: string | null;
+  manufacturerName: string | null;
+  currentQuantity: number;
+  currentRevenue: number;
+  currentCogs: number;
+  currentMargin: number;
+  previousQuantity: number;
+  previousRevenue: number;
+  stock: number;
+  stockValue: number;
+  supplierStock: number;
+  daysCover: number | null;
+  lastSupplierId: string | null;
+  lastSupplierName: string | null;
+  lastUnitCost: number | null;
+  lastPurchaseDate: string | null;
+  lastSoldOn: string | null;
+  trend: number[];
+}
+
+export interface RestockIntelligence {
+  days: number;
+  lowStockThreshold: number;
+  summary: {
+    products: number;
+    unitsSold: number;
+    sales: number;
+    stock: number;
+    stockValue: number;
+    restockRisks: number;
+  };
+  trend: RestockTrendPoint[];
+  products: RestockProductRow[];
 }
 
 export interface DashboardLocationSummary {
@@ -79,6 +140,7 @@ export class ReportsService {
     return {
       summary: snapshot?.summary ?? [],
       topVariants: snapshot?.topVariants ?? [],
+      productSignals: snapshot?.productSignals ?? { restockRisks: [], fastVariants: [] },
       locations: snapshot?.locations ?? [],
       comparison: snapshot?.comparison ?? {
         current_revenue: 0,
@@ -89,6 +151,59 @@ export class ReportsService {
         previous_orders: 0,
       },
       ...(snapshot?.refreshAfter ? { refreshAfter: snapshot.refreshAfter } : {}),
+    };
+  }
+
+  async restockIntelligence(
+    since: string,
+    until: string,
+    locationId: string,
+    scope: { supplierId: string | null; manufacturerId: string | null },
+    limit = 50
+  ): Promise<RestockIntelligence> {
+    const { data, error } = await this.db.rpc('restock_product_intelligence', {
+      p_since: since,
+      p_until: until,
+      p_location_id: locationId,
+      p_supplier_id: scope.supplierId ?? undefined,
+      p_manufacturer_id: scope.manufacturerId ?? undefined,
+      p_limit: limit,
+    });
+    if (error) throw error;
+    const value = (data ?? {}) as unknown as Partial<RestockIntelligence>;
+    return {
+      days: Number(value.days ?? 0),
+      lowStockThreshold: Number(value.lowStockThreshold ?? 0),
+      summary: {
+        products: Number(value.summary?.products ?? 0),
+        unitsSold: Number(value.summary?.unitsSold ?? 0),
+        sales: Number(value.summary?.sales ?? 0),
+        stock: Number(value.summary?.stock ?? 0),
+        stockValue: Number(value.summary?.stockValue ?? 0),
+        restockRisks: Number(value.summary?.restockRisks ?? 0),
+      },
+      trend: (value.trend ?? []).map(point => ({
+        day: point.day,
+        currentQuantity: Number(point.currentQuantity ?? 0),
+        previousQuantity: Number(point.previousQuantity ?? 0),
+        currentRevenue: Number(point.currentRevenue ?? 0),
+        previousRevenue: Number(point.previousRevenue ?? 0),
+      })),
+      products: (value.products ?? []).map(product => ({
+        ...product,
+        currentQuantity: Number(product.currentQuantity ?? 0),
+        currentRevenue: Number(product.currentRevenue ?? 0),
+        currentCogs: Number(product.currentCogs ?? 0),
+        currentMargin: Number(product.currentMargin ?? 0),
+        previousQuantity: Number(product.previousQuantity ?? 0),
+        previousRevenue: Number(product.previousRevenue ?? 0),
+        stock: Number(product.stock ?? 0),
+        stockValue: Number(product.stockValue ?? 0),
+        supplierStock: Number(product.supplierStock ?? 0),
+        daysCover: product.daysCover === null ? null : Number(product.daysCover),
+        lastUnitCost: product.lastUnitCost === null ? null : Number(product.lastUnitCost),
+        trend: (product.trend ?? []).map(Number),
+      })),
     };
   }
 

--- a/apps/web/src/app/reports/restock-intelligence.component.spec.ts
+++ b/apps/web/src/app/reports/restock-intelligence.component.spec.ts
@@ -1,0 +1,183 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+import { CatalogCacheService } from '../core/catalog-cache.service';
+import { LocationContextService } from '../core/location-context.service';
+import { PartyCacheService } from '../core/party-cache.service';
+import { IconComponent } from '../shared/ui/icon.component';
+import { RestockIntelligenceComponent } from './restock-intelligence.component';
+import { ReportsService, type RestockIntelligence } from './reports.service';
+
+const report: RestockIntelligence = {
+  days: 30,
+  lowStockThreshold: 5,
+  summary: {
+    products: 1,
+    unitsSold: 12,
+    sales: 12_000,
+    stock: 3,
+    stockValue: 1_800,
+    restockRisks: 1,
+  },
+  trend: [
+    {
+      day: '2026-08-21',
+      currentQuantity: 5,
+      previousQuantity: 2,
+      currentRevenue: 5_000,
+      previousRevenue: 2_000,
+    },
+    {
+      day: '2026-08-22',
+      currentQuantity: 7,
+      previousQuantity: 4,
+      currentRevenue: 7_000,
+      previousRevenue: 4_000,
+    },
+  ],
+  products: [
+    {
+      variantId: 'variant-1',
+      productId: 'product-1',
+      productName: 'Tea',
+      variantName: 'Default',
+      manufacturerId: 'manufacturer-1',
+      manufacturerName: 'Acme',
+      currentQuantity: 12,
+      currentRevenue: 12_000,
+      currentCogs: 7_200,
+      currentMargin: 4_800,
+      previousQuantity: 6,
+      previousRevenue: 6_000,
+      stock: 3,
+      stockValue: 1_800,
+      supplierStock: 3,
+      daysCover: 7.5,
+      lastSupplierId: 'supplier-1',
+      lastSupplierName: 'Fresh Supply',
+      lastUnitCost: 600,
+      lastPurchaseDate: '2026-08-10',
+      lastSoldOn: '2026-08-22',
+      trend: [0, 5, 7],
+    },
+  ],
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('RestockIntelligenceComponent', () => {
+  async function render(
+    restockIntelligence = vi.fn().mockResolvedValue(report),
+    manufacturers = [{ id: 'manufacturer-1', name: 'Acme' }]
+  ) {
+    await TestBed.configureTestingModule({
+      imports: [RestockIntelligenceComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ReportsService, useValue: { restockIntelligence } },
+        {
+          provide: CatalogCacheService,
+          useValue: {
+            manufacturers: signal(manufacturers),
+            ensureLoaded: vi.fn().mockResolvedValue(true),
+          },
+        },
+        {
+          provide: PartyCacheService,
+          useValue: {
+            suppliers: signal([
+              {
+                id: 'supplier-1',
+                first_name: 'Fresh Supply',
+                last_name: null,
+                supplier_active: true,
+                deleted_at: null,
+              },
+            ]),
+            ensureLoaded: vi.fn().mockResolvedValue(true),
+          },
+        },
+        {
+          provide: LocationContextService,
+          useValue: {
+            locations: signal([{ id: 'location-1', name: 'Main shop' }]),
+            activeId: signal('location-1'),
+            load: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    })
+      .overrideComponent(IconComponent, { set: { template: '' } })
+      .compileComponents();
+    const fixture = TestBed.createComponent(RestockIntelligenceComponent);
+    fixture.componentRef.setInput('since', '2026-07-24');
+    fixture.componentRef.setInput('until', '2026-08-22');
+    fixture.detectChanges();
+    return { fixture, restockIntelligence };
+  }
+
+  it('loads the working location and renders visual restocking facts', async () => {
+    const { fixture, restockIntelligence } = await render();
+    await vi.waitFor(() => {
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('Demand trend');
+    });
+    expect(restockIntelligence).toHaveBeenCalledWith(
+      '2026-07-24',
+      '2026-08-22',
+      'location-1',
+      { supplierId: 'supplier-1', manufacturerId: null },
+      50
+    );
+    expect(fixture.nativeElement.textContent).toContain('Fresh Supply');
+    expect(fixture.nativeElement.textContent).toContain('Restock now');
+    expect(fixture.nativeElement.querySelector('[role="img"]')).not.toBeNull();
+  });
+
+  it('does not let an older source response overwrite a newer one', async () => {
+    const first = deferred<RestockIntelligence>();
+    const newer = { ...report, summary: { ...report.summary, products: 2 } };
+    const restockIntelligence = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(newer);
+    const { fixture } = await render(restockIntelligence);
+    await vi.waitFor(() => expect(restockIntelligence).toHaveBeenCalledTimes(1));
+    (fixture.componentInstance as any).setScopeMode('manufacturer');
+    await vi.waitFor(() => expect(restockIntelligence).toHaveBeenCalledTimes(2));
+    first.resolve(report);
+    await vi.waitFor(() => {
+      fixture.detectChanges();
+      expect((fixture.componentInstance as any).report().summary.products).toBe(2);
+    });
+  });
+
+  it('disables an unavailable source and invalidates its pending response', async () => {
+    const first = deferred<RestockIntelligence>();
+    const restockIntelligence = vi.fn().mockReturnValue(first.promise);
+    const { fixture } = await render(restockIntelligence, []);
+    await vi.waitFor(() => expect(restockIntelligence).toHaveBeenCalledTimes(1));
+
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button')
+    ) as HTMLButtonElement[];
+    const manufacturerButton = buttons.find(button =>
+      button.textContent?.includes('Manufacturer')
+    ) as HTMLButtonElement;
+    expect(manufacturerButton.disabled).toBe(true);
+
+    (fixture.componentInstance as any).setScopeMode('manufacturer');
+    first.resolve(report);
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect((fixture.componentInstance as any).report()).toBeNull();
+    expect((fixture.componentInstance as any).loading()).toBe(false);
+  });
+});

--- a/apps/web/src/app/reports/restock-intelligence.component.ts
+++ b/apps/web/src/app/reports/restock-intelligence.component.ts
@@ -1,0 +1,663 @@
+import {
+  Component,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  untracked,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CatalogCacheService } from '../core/catalog-cache.service';
+import { LocationContextService } from '../core/location-context.service';
+import { formatKes } from '../core/money';
+import { PartyCacheService } from '../core/party-cache.service';
+import { EmptyStateComponent } from '../shared/ui/empty-state.component';
+import { IconComponent } from '../shared/ui/icon.component';
+import {
+  coverWidth,
+  quantityChangeLabel,
+  restockDecision,
+  sparklineHeights,
+} from './restock-intelligence';
+import { RestockTrendChartComponent } from './restock-trend-chart.component';
+import {
+  ReportsService,
+  type RestockIntelligence,
+  type RestockProductRow,
+} from './reports.service';
+
+type ScopeMode = 'supplier' | 'manufacturer';
+type TrendMetric = 'quantity' | 'revenue';
+
+type DisplayProduct = RestockProductRow & {
+  label: string;
+  decision: ReturnType<typeof restockDecision>;
+  changeLabel: string;
+  trendHeights: number[];
+};
+
+@Component({
+  selector: 'app-restock-intelligence',
+  imports: [RouterLink, EmptyStateComponent, IconComponent, RestockTrendChartComponent],
+  template: `
+    <section aria-labelledby="restock-title">
+      <div class="border-y border-base-300 bg-base-100 px-3 py-3 sm:px-4">
+        <div class="flex flex-wrap items-end gap-3">
+          <div>
+            <span class="label-text text-xs">Product source</span>
+            <div class="mt-1 flex min-h-11 rounded-field border border-base-300 bg-base-200/40 p-1">
+              <button
+                type="button"
+                class="flex min-w-28 items-center justify-center gap-2 rounded-field px-3 text-sm"
+                [class.bg-base-100]="scopeMode() === 'supplier'"
+                [class.font-semibold]="scopeMode() === 'supplier'"
+                [attr.aria-pressed]="scopeMode() === 'supplier'"
+                [disabled]="loading() || supplierOptions().length === 0"
+                (click)="setScopeMode('supplier')"
+              >
+                <app-icon name="heroTruck" /> Supplier
+              </button>
+              <button
+                type="button"
+                class="flex min-w-32 items-center justify-center gap-2 rounded-field px-3 text-sm"
+                [class.bg-base-100]="scopeMode() === 'manufacturer'"
+                [class.font-semibold]="scopeMode() === 'manufacturer'"
+                [attr.aria-pressed]="scopeMode() === 'manufacturer'"
+                [disabled]="loading() || manufacturerOptions().length === 0"
+                (click)="setScopeMode('manufacturer')"
+              >
+                <app-icon name="heroCube" /> Manufacturer
+              </button>
+            </div>
+          </div>
+
+          <label class="form-control min-w-56 flex-1 sm:max-w-80">
+            <span class="label-text text-xs">
+              {{ scopeMode() === 'supplier' ? 'Supplier' : 'Manufacturer' }}
+            </span>
+            @if (scopeMode() === 'supplier') {
+              <select
+                class="select select-bordered min-h-11 w-full"
+                [value]="selectedSupplier()"
+                [disabled]="loading()"
+                (change)="setSupplier($event)"
+              >
+                @for (supplier of supplierOptions(); track supplier.id) {
+                  <option [value]="supplier.id">{{ supplier.label }}</option>
+                }
+              </select>
+            } @else {
+              <select
+                class="select select-bordered min-h-11 w-full"
+                [value]="selectedManufacturer()"
+                [disabled]="loading()"
+                (change)="setManufacturer($event)"
+              >
+                @for (manufacturer of manufacturerOptions(); track manufacturer.id) {
+                  <option [value]="manufacturer.id">{{ manufacturer.name }}</option>
+                }
+              </select>
+            }
+          </label>
+
+          <label class="form-control min-w-52 sm:max-w-64">
+            <span class="label-text text-xs">Stock location</span>
+            <select
+              class="select select-bordered min-h-11 w-full"
+              [value]="selectedLocation()"
+              [disabled]="loading()"
+              (change)="setLocation($event)"
+            >
+              @for (location of locations.locations(); track location.id) {
+                <option [value]="location.id">{{ location.name }}</option>
+              }
+            </select>
+          </label>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-square min-h-11 min-w-11"
+            title="Refresh restocking data"
+            aria-label="Refresh restocking data"
+            [disabled]="loading() || !hasScope()"
+            (click)="load()"
+          >
+            <app-icon name="heroArrowPath" />
+          </button>
+        </div>
+      </div>
+
+      @if (!hasAnySource()) {
+        <app-empty-state
+          [compact]="true"
+          icon="heroTruck"
+          title="Add a supplier or manufacturer first"
+          description="Restocking performance is grouped by the source you buy from."
+        />
+      } @else if (error()) {
+        <div role="alert" class="alert alert-error my-4 text-sm">
+          <app-icon name="heroExclamationTriangle" />
+          <span>{{ error() }}</span>
+          <button type="button" class="btn btn-ghost btn-sm" (click)="load()">Retry</button>
+        </div>
+      } @else if (loading() && !report()) {
+        <div role="status" class="flex min-h-72 items-center justify-center gap-2 text-sm">
+          <span class="loading loading-spinner loading-sm"></span>
+          Loading restocking performance
+        </div>
+      } @else if (report(); as data) {
+        <header class="flex flex-wrap items-end justify-between gap-2 py-4">
+          <div>
+            <h2 id="restock-title" class="type-title">{{ selectedScopeName() }}</h2>
+            <p class="type-caption mt-1">
+              {{ selectedLocationName() }} · {{ data.days }} days · compared with the previous equal
+              period
+            </p>
+          </div>
+          @if (loading()) {
+            <span class="flex items-center gap-2 text-xs text-base-content/60">
+              <span class="loading loading-spinner loading-xs"></span> Refreshing
+            </span>
+          }
+        </header>
+
+        <div class="grid grid-cols-2 border-y border-base-300 bg-base-100 xl:grid-cols-5">
+          <div class="border-b border-r border-base-300 px-4 py-3 xl:border-b-0">
+            <p class="type-caption">Products</p>
+            <p class="type-title mt-1 tabular-nums">{{ data.summary.products }}</p>
+          </div>
+          <div class="border-b border-base-300 px-4 py-3 xl:border-b-0 xl:border-r">
+            <p class="type-caption">Units sold</p>
+            <p class="type-title mt-1 tabular-nums">{{ quantity(data.summary.unitsSold) }}</p>
+          </div>
+          <div class="border-b border-r border-base-300 px-4 py-3 xl:border-b-0">
+            <p class="type-caption">Sales</p>
+            <p class="type-title mt-1 tabular-nums">{{ fmt(data.summary.sales) }}</p>
+          </div>
+          <div class="border-b border-base-300 px-4 py-3 xl:border-b-0 xl:border-r">
+            <p class="type-caption">Stock on hand</p>
+            <p class="type-title mt-1 tabular-nums">{{ quantity(data.summary.stock) }}</p>
+          </div>
+          <div class="col-span-2 px-4 py-3 xl:col-span-1">
+            <p class="type-caption">Needs attention</p>
+            <p
+              class="type-title mt-1 tabular-nums"
+              [class.text-error]="data.summary.restockRisks > 0"
+            >
+              {{ data.summary.restockRisks }}
+            </p>
+          </div>
+        </div>
+
+        @if (data.products.length === 0) {
+          <app-empty-state
+            [compact]="true"
+            icon="heroCube"
+            title="No stocked products for this source"
+            description="Try another location, supplier, manufacturer, or reporting period."
+          />
+        } @else {
+          <div class="mt-4 grid items-start gap-4 xl:grid-cols-12">
+            <article class="card overflow-hidden bg-base-100 xl:col-span-8">
+              <div
+                class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300 px-4 py-3"
+              >
+                <div>
+                  <h3 class="section-title">Demand trend</h3>
+                  <p class="type-caption mt-1">Completed sales for the selected product source.</p>
+                </div>
+                <div class="flex rounded-field border border-base-300 bg-base-200/40 p-1">
+                  <button
+                    type="button"
+                    class="min-h-11 rounded-field px-3 text-xs"
+                    [class.bg-base-100]="trendMetric() === 'quantity'"
+                    [class.font-semibold]="trendMetric() === 'quantity'"
+                    (click)="trendMetric.set('quantity')"
+                  >
+                    Units
+                  </button>
+                  <button
+                    type="button"
+                    class="min-h-11 rounded-field px-3 text-xs"
+                    [class.bg-base-100]="trendMetric() === 'revenue'"
+                    [class.font-semibold]="trendMetric() === 'revenue'"
+                    (click)="trendMetric.set('revenue')"
+                  >
+                    Sales
+                  </button>
+                </div>
+              </div>
+              <div class="p-4">
+                @if (trendHasData()) {
+                  <app-restock-trend-chart [points]="data.trend" [metric]="trendMetric()" />
+                } @else {
+                  <app-empty-state
+                    [embedded]="true"
+                    [compact]="true"
+                    icon="heroChartBar"
+                    title="No sales in these periods"
+                    description="Stock remains visible while demand data builds from completed sales."
+                  />
+                }
+              </div>
+            </article>
+
+            <article class="card overflow-hidden bg-base-100 xl:col-span-4">
+              <div class="border-b border-base-300 px-4 py-3">
+                <h3 class="section-title">Stock coverage</h3>
+                <p class="type-caption mt-1">Days on hand at the current sales pace.</p>
+              </div>
+              @if (coverageProducts().length === 0) {
+                <app-empty-state
+                  [embedded]="true"
+                  [compact]="true"
+                  icon="heroCube"
+                  title="No recent demand"
+                  description="Coverage appears after products begin selling."
+                />
+              } @else {
+                <div class="divide-y divide-base-200 px-4">
+                  @for (product of coverageProducts(); track product.variantId) {
+                    <div class="py-3">
+                      <div class="mb-1.5 flex items-center justify-between gap-3 text-xs">
+                        <span class="truncate font-medium">{{ product.label }}</span>
+                        <span class="shrink-0 tabular-nums">{{
+                          daysCover(product.daysCover)
+                        }}</span>
+                      </div>
+                      <div class="relative h-2 overflow-hidden rounded-field bg-base-200">
+                        <span
+                          class="absolute inset-y-0 left-[23.33%] z-10 border-l border-error/70"
+                        ></span>
+                        <span
+                          class="block h-full rounded-field"
+                          [class.bg-error]="product.decision.tone === 'error'"
+                          [class.bg-warning]="product.decision.tone === 'warning'"
+                          [class.bg-info]="product.decision.tone === 'info'"
+                          [class.bg-success]="product.decision.tone === 'success'"
+                          [style.width.%]="coverageWidth(product.daysCover)"
+                        ></span>
+                      </div>
+                    </div>
+                  }
+                </div>
+                <p class="border-t border-base-300 px-4 py-2 text-xs text-base-content/60">
+                  Marker shows 14 days of cover.
+                </p>
+              }
+            </article>
+          </div>
+
+          <div
+            class="mt-4 overflow-hidden border-y border-base-300 bg-base-100 lg:rounded-box lg:border"
+          >
+            <div
+              class="flex flex-wrap items-end justify-between gap-2 border-b border-base-300 px-4 py-3"
+            >
+              <div>
+                <h3 class="section-title">Restocking decisions</h3>
+                <p class="type-caption mt-1">
+                  Urgent products first, based on stock and recent demand.
+                </p>
+              </div>
+              <span class="type-caption">Top {{ data.products.length }} products</span>
+            </div>
+
+            <div class="divide-y divide-base-200 lg:hidden">
+              @for (product of displayProducts(); track product.variantId) {
+                <a
+                  class="block p-4 hover:bg-base-200/40"
+                  routerLink="/inventory/products"
+                  [queryParams]="{ product: product.productId, variant: product.variantId }"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="truncate font-semibold">{{ product.label }}</p>
+                      <p class="type-caption mt-1 truncate">
+                        {{ productContext(product) }}
+                      </p>
+                    </div>
+                    <span class="badge badge-sm shrink-0" [class]="decisionClass(product)">
+                      {{ product.decision.label }}
+                    </span>
+                  </div>
+                  <div class="mt-3 grid grid-cols-3 gap-3 text-sm">
+                    <div>
+                      <p class="type-caption">Sold</p>
+                      <p class="font-semibold tabular-nums">
+                        {{ quantity(product.currentQuantity) }}
+                      </p>
+                      <p
+                        class="text-xs"
+                        [class.text-success]="product.currentQuantity > product.previousQuantity"
+                        [class.text-error]="product.currentQuantity < product.previousQuantity"
+                      >
+                        {{ product.changeLabel }}
+                      </p>
+                    </div>
+                    <div>
+                      <p class="type-caption">In stock</p>
+                      <p class="font-semibold tabular-nums">{{ quantity(product.stock) }}</p>
+                      @if (scopeMode() === 'supplier') {
+                        <p class="text-xs text-base-content/60">
+                          {{ quantity(product.supplierStock) }} sourced here
+                        </p>
+                      }
+                    </div>
+                    <div>
+                      <p class="type-caption">Cover</p>
+                      <p class="font-semibold tabular-nums">{{ daysCover(product.daysCover) }}</p>
+                    </div>
+                  </div>
+                </a>
+              }
+            </div>
+
+            <div class="hidden overflow-x-auto lg:block">
+              <table class="table table-sm">
+                <thead>
+                  <tr>
+                    <th>Product</th>
+                    <th>Demand trend</th>
+                    <th class="text-right">Units sold</th>
+                    <th class="text-right">Stock</th>
+                    <th class="text-right">Cover</th>
+                    <th class="text-right">Last cost</th>
+                    <th>Decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (product of displayProducts(); track product.variantId) {
+                    <tr>
+                      <td class="max-w-64">
+                        <a
+                          class="link block truncate font-medium"
+                          routerLink="/inventory/products"
+                          [queryParams]="{ product: product.productId, variant: product.variantId }"
+                        >
+                          {{ product.label }}
+                        </a>
+                        <p class="type-caption truncate">
+                          {{ productContext(product) }}
+                          @if (product.lastSoldOn) {
+                            · sold {{ shortDate(product.lastSoldOn) }}
+                          }
+                        </p>
+                      </td>
+                      <td class="w-36">
+                        <div
+                          class="flex h-9 items-end gap-0.5"
+                          role="img"
+                          [attr.aria-label]="product.label + ' daily sales trend'"
+                        >
+                          @for (height of product.trendHeights; track $index) {
+                            <span
+                              class="min-w-1 flex-1 rounded-t-field bg-primary/70"
+                              [style.height.%]="height"
+                            ></span>
+                          }
+                        </div>
+                      </td>
+                      <td class="text-right">
+                        <p class="font-medium tabular-nums">
+                          {{ quantity(product.currentQuantity) }}
+                        </p>
+                        <p
+                          class="text-xs tabular-nums"
+                          [class.text-success]="product.currentQuantity > product.previousQuantity"
+                          [class.text-error]="product.currentQuantity < product.previousQuantity"
+                        >
+                          {{ product.changeLabel }}
+                        </p>
+                      </td>
+                      <td class="text-right">
+                        <p class="font-medium tabular-nums">{{ quantity(product.stock) }}</p>
+                        @if (scopeMode() === 'supplier') {
+                          <p class="text-xs text-base-content/60">
+                            {{ quantity(product.supplierStock) }} from supplier
+                          </p>
+                        } @else {
+                          <p class="text-xs text-base-content/60">
+                            {{ fmt(product.stockValue) }} value
+                          </p>
+                        }
+                      </td>
+                      <td class="text-right font-medium tabular-nums">
+                        {{ daysCover(product.daysCover) }}
+                      </td>
+                      <td class="text-right">
+                        <p class="font-medium tabular-nums">
+                          {{ product.lastUnitCost === null ? '—' : fmt(product.lastUnitCost) }}
+                        </p>
+                        <p class="type-caption">
+                          {{
+                            product.lastPurchaseDate
+                              ? shortDate(product.lastPurchaseDate)
+                              : 'No receipt'
+                          }}
+                        </p>
+                      </td>
+                      <td>
+                        <span class="badge badge-sm" [class]="decisionClass(product)">
+                          {{ product.decision.label }}
+                        </span>
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          </div>
+        }
+      }
+    </section>
+  `,
+})
+export class RestockIntelligenceComponent implements OnInit {
+  readonly since = input.required<string>();
+  readonly until = input.required<string>();
+
+  private readonly reports = inject(ReportsService);
+  private readonly catalog = inject(CatalogCacheService);
+  private readonly parties = inject(PartyCacheService);
+  protected readonly locations = inject(LocationContextService);
+
+  protected readonly fmt = formatKes;
+  protected readonly scopeMode = signal<ScopeMode>('supplier');
+  protected readonly trendMetric = signal<TrendMetric>('quantity');
+  protected readonly selectedSupplier = signal('');
+  protected readonly selectedManufacturer = signal('');
+  protected readonly selectedLocation = signal('');
+  protected readonly report = signal<RestockIntelligence | null>(null);
+  protected readonly loading = signal(false);
+  protected readonly error = signal<string | null>(null);
+  private readonly ready = signal(false);
+  private request = 0;
+
+  protected readonly supplierOptions = computed(() =>
+    this.parties
+      .suppliers()
+      .filter(supplier => supplier.supplier_active && !supplier.deleted_at)
+      .map(supplier => ({
+        id: supplier.id,
+        label: [supplier.first_name, supplier.last_name].filter(Boolean).join(' '),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  );
+  protected readonly manufacturerOptions = computed(() =>
+    [...this.catalog.manufacturers()].sort((a, b) => a.name.localeCompare(b.name))
+  );
+  protected readonly hasAnySource = computed(
+    () => this.supplierOptions().length > 0 || this.manufacturerOptions().length > 0
+  );
+  protected readonly hasScope = computed(() =>
+    this.scopeMode() === 'supplier' ? !!this.selectedSupplier() : !!this.selectedManufacturer()
+  );
+  protected readonly selectedScopeName = computed(() => {
+    if (this.scopeMode() === 'supplier') {
+      return (
+        this.supplierOptions().find(item => item.id === this.selectedSupplier())?.label ??
+        'Supplier'
+      );
+    }
+    return (
+      this.manufacturerOptions().find(item => item.id === this.selectedManufacturer())?.name ??
+      'Manufacturer'
+    );
+  });
+  protected readonly selectedLocationName = computed(
+    () =>
+      this.locations.locations().find(item => item.id === this.selectedLocation())?.name ??
+      'Location'
+  );
+  protected readonly displayProducts = computed<DisplayProduct[]>(() => {
+    const data = this.report();
+    if (!data) return [];
+    return data.products.map(product => ({
+      ...product,
+      label:
+        !product.variantName || product.variantName === 'Default'
+          ? product.productName
+          : `${product.productName} — ${product.variantName}`,
+      decision: restockDecision(product, data.lowStockThreshold),
+      changeLabel: quantityChangeLabel(product.currentQuantity, product.previousQuantity),
+      trendHeights: sparklineHeights(product.trend),
+    }));
+  });
+  protected readonly coverageProducts = computed(() =>
+    this.displayProducts()
+      .filter(product => product.currentQuantity > 0 && product.daysCover !== null)
+      .sort((a, b) => (a.daysCover ?? Infinity) - (b.daysCover ?? Infinity))
+      .slice(0, 8)
+  );
+  protected readonly trendHasData = computed(() => {
+    const data = this.report();
+    if (!data) return false;
+    return data.trend.some(point =>
+      this.trendMetric() === 'quantity'
+        ? point.currentQuantity > 0 || point.previousQuantity > 0
+        : point.currentRevenue > 0 || point.previousRevenue > 0
+    );
+  });
+
+  constructor() {
+    effect(() => {
+      const since = this.since();
+      const until = this.until();
+      if (!this.ready()) return;
+      untracked(() => void this.load(since, until));
+    });
+  }
+
+  async ngOnInit(): Promise<void> {
+    await Promise.all([
+      this.catalog.ensureLoaded(),
+      this.parties.ensureLoaded(),
+      this.locations.load(),
+    ]);
+    const suppliers = this.supplierOptions();
+    const manufacturers = this.manufacturerOptions();
+    if (suppliers.length > 0) {
+      this.selectedSupplier.set(suppliers[0].id);
+    } else if (manufacturers.length > 0) {
+      this.scopeMode.set('manufacturer');
+      this.selectedManufacturer.set(manufacturers[0].id);
+    }
+    if (manufacturers.length > 0 && !this.selectedManufacturer()) {
+      this.selectedManufacturer.set(manufacturers[0].id);
+    }
+    this.selectedLocation.set(this.locations.activeId() ?? this.locations.locations()[0]?.id ?? '');
+    this.ready.set(true);
+  }
+
+  protected setScopeMode(mode: ScopeMode): void {
+    if (this.scopeMode() === mode) return;
+    this.scopeMode.set(mode);
+    if (mode === 'supplier' && !this.selectedSupplier()) {
+      this.selectedSupplier.set(this.supplierOptions()[0]?.id ?? '');
+    }
+    if (mode === 'manufacturer' && !this.selectedManufacturer()) {
+      this.selectedManufacturer.set(this.manufacturerOptions()[0]?.id ?? '');
+    }
+    void this.load();
+  }
+
+  protected setSupplier(event: Event): void {
+    this.selectedSupplier.set((event.target as HTMLSelectElement).value);
+    void this.load();
+  }
+
+  protected setManufacturer(event: Event): void {
+    this.selectedManufacturer.set((event.target as HTMLSelectElement).value);
+    void this.load();
+  }
+
+  protected setLocation(event: Event): void {
+    this.selectedLocation.set((event.target as HTMLSelectElement).value);
+    void this.load();
+  }
+
+  protected async load(since = this.since(), until = this.until()): Promise<void> {
+    const locationId = this.selectedLocation();
+    const supplierId = this.scopeMode() === 'supplier' ? this.selectedSupplier() : null;
+    const manufacturerId = this.scopeMode() === 'manufacturer' ? this.selectedManufacturer() : null;
+    const request = ++this.request;
+    if (!locationId || (!supplierId && !manufacturerId)) {
+      this.loading.set(false);
+      this.error.set(null);
+      this.report.set(null);
+      return;
+    }
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const report = await this.reports.restockIntelligence(
+        since,
+        until,
+        locationId,
+        { supplierId, manufacturerId },
+        50
+      );
+      if (request !== this.request) return;
+      this.report.set(report);
+    } catch (error) {
+      if (request !== this.request) return;
+      this.error.set(error instanceof Error ? error.message : 'Could not load restocking data');
+    } finally {
+      if (request === this.request) this.loading.set(false);
+    }
+  }
+
+  protected quantity(value: number): string {
+    return Number(value).toLocaleString('en-KE', { maximumFractionDigits: 2 });
+  }
+
+  protected daysCover(value: number | null): string {
+    if (value === null) return 'No pace';
+    if (value > 365) return '365+ days';
+    return `${value.toLocaleString('en-KE', { maximumFractionDigits: 1 })} days`;
+  }
+
+  protected coverageWidth(value: number | null): number {
+    return coverWidth(value);
+  }
+
+  protected shortDate(value: string): string {
+    return new Intl.DateTimeFormat('en-KE', { day: 'numeric', month: 'short' }).format(
+      new Date(`${value}T00:00:00Z`)
+    );
+  }
+
+  protected productContext(product: DisplayProduct): string {
+    if (this.scopeMode() === 'manufacturer' && product.lastSupplierName) {
+      return `Last supplied by ${product.lastSupplierName}`;
+    }
+    return product.manufacturerName || 'Manufacturer not set';
+  }
+
+  protected decisionClass(product: DisplayProduct): string {
+    return `badge-${product.decision.tone}`;
+  }
+}

--- a/apps/web/src/app/reports/restock-intelligence.ts
+++ b/apps/web/src/app/reports/restock-intelligence.ts
@@ -1,0 +1,52 @@
+import type { RestockProductRow } from './reports.service';
+
+export type RestockDecisionTone = 'error' | 'warning' | 'info' | 'success' | 'neutral';
+
+export interface RestockDecision {
+  label: string;
+  tone: RestockDecisionTone;
+  priority: number;
+}
+
+export function restockDecision(
+  product: Pick<RestockProductRow, 'currentQuantity' | 'previousQuantity' | 'stock' | 'daysCover'>,
+  lowStockThreshold: number
+): RestockDecision {
+  const hasRecentDemand = product.currentQuantity > 0 || product.previousQuantity > 0;
+  if (hasRecentDemand && product.stock <= lowStockThreshold) {
+    return { label: 'Restock now', tone: 'error', priority: 0 };
+  }
+  if (product.currentQuantity <= 0) {
+    return { label: 'Slow-moving', tone: 'neutral', priority: 4 };
+  }
+  if (product.daysCover !== null && product.daysCover <= 14) {
+    return { label: 'Restock soon', tone: 'warning', priority: 1 };
+  }
+  if (
+    product.currentQuantity > product.previousQuantity &&
+    product.daysCover !== null &&
+    product.daysCover <= 30
+  ) {
+    return { label: 'Demand rising', tone: 'info', priority: 2 };
+  }
+  return { label: 'Stock healthy', tone: 'success', priority: 3 };
+}
+
+export function quantityChangeLabel(current: number, previous: number): string {
+  if (previous === 0) return current > 0 ? 'New demand' : 'No change';
+  const change = ((current - previous) / Math.abs(previous)) * 100;
+  return `${change > 0 ? '+' : ''}${change.toLocaleString('en-KE', {
+    maximumFractionDigits: 1,
+  })}%`;
+}
+
+export function sparklineHeights(values: number[], maximumBars = 18): number[] {
+  const selected = values.slice(-maximumBars);
+  const maximum = Math.max(...selected, 1);
+  return selected.map(value => (value <= 0 ? 4 : Math.max(12, (value / maximum) * 100)));
+}
+
+export function coverWidth(daysCover: number | null, maximumDays = 60): number {
+  if (daysCover === null) return 0;
+  return Math.min(Math.max((daysCover / maximumDays) * 100, 0), 100);
+}

--- a/apps/web/src/app/reports/restock-intelligence.unit.spec.ts
+++ b/apps/web/src/app/reports/restock-intelligence.unit.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coverWidth,
+  quantityChangeLabel,
+  restockDecision,
+  sparklineHeights,
+} from './restock-intelligence';
+
+const facts = (
+  currentQuantity: number,
+  previousQuantity: number,
+  stock: number,
+  daysCover: number | null
+) => ({ currentQuantity, previousQuantity, stock, daysCover });
+
+describe('restock intelligence presentation', () => {
+  it('prioritizes low stock and short cover before rising demand', () => {
+    expect(restockDecision(facts(20, 10, 2, 3), 5).label).toBe('Restock now');
+    expect(restockDecision(facts(20, 10, 20, 10), 5).label).toBe('Restock soon');
+    expect(restockDecision(facts(20, 10, 50, 25), 5).label).toBe('Demand rising');
+  });
+
+  it('separates healthy and slow-moving stock', () => {
+    expect(restockDecision(facts(10, 10, 60, 60), 5).label).toBe('Stock healthy');
+    expect(restockDecision(facts(0, 4, 60, null), 5).label).toBe('Slow-moving');
+  });
+
+  it('treats a sold-out product with prior demand as a restock risk', () => {
+    expect(restockDecision(facts(0, 4, 0, null), 5).label).toBe('Restock now');
+  });
+
+  it('describes demand changes without infinite percentages', () => {
+    expect(quantityChangeLabel(5, 0)).toBe('New demand');
+    expect(quantityChangeLabel(12, 10)).toBe('+20%');
+    expect(quantityChangeLabel(5, 10)).toBe('-50%');
+  });
+
+  it('normalizes sparklines and coverage bars to stable percentages', () => {
+    expect(sparklineHeights([0, 2, 4])).toEqual([4, 50, 100]);
+    expect(coverWidth(null)).toBe(0);
+    expect(coverWidth(14)).toBeCloseTo(23.333, 2);
+    expect(coverWidth(90)).toBe(100);
+  });
+});

--- a/apps/web/src/app/reports/restock-trend-chart.component.spec.ts
+++ b/apps/web/src/app/reports/restock-trend-chart.component.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { RestockTrendChartComponent } from './restock-trend-chart.component';
+
+describe('RestockTrendChartComponent', () => {
+  it('labels the peak across both comparison periods', async () => {
+    await TestBed.configureTestingModule({
+      imports: [RestockTrendChartComponent],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(RestockTrendChartComponent);
+    fixture.componentRef.setInput('points', [
+      {
+        day: '2026-08-22',
+        currentQuantity: 4,
+        previousQuantity: 12,
+        currentRevenue: 4_000,
+        previousRevenue: 12_000,
+      },
+    ]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('12 peak');
+  });
+});

--- a/apps/web/src/app/reports/restock-trend-chart.component.ts
+++ b/apps/web/src/app/reports/restock-trend-chart.component.ts
@@ -1,0 +1,127 @@
+import { Component, computed, input } from '@angular/core';
+import type { RestockTrendPoint } from './reports.service';
+
+type TrendMetric = 'quantity' | 'revenue';
+
+@Component({
+  selector: 'app-restock-trend-chart',
+  template: `
+    <div class="w-full">
+      <div class="mb-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
+        <span class="flex items-center gap-2 font-medium">
+          <span class="h-0.5 w-5 bg-primary"></span>Current period
+        </span>
+        <span class="flex items-center gap-2 text-base-content/60">
+          <span class="h-0.5 w-5 border-t-2 border-dashed border-base-content/40"></span>
+          Previous period
+        </span>
+        <span class="ml-auto text-base-content/60">{{ peakLabel() }} peak</span>
+      </div>
+
+      <div
+        class="relative h-64 overflow-x-auto overflow-y-hidden border-y border-base-300/70 bg-base-200/20"
+        role="img"
+        [attr.aria-label]="ariaLabel()"
+      >
+        <span
+          class="pointer-events-none absolute inset-x-0 top-1/4 border-t border-base-300/70"
+        ></span>
+        <span
+          class="pointer-events-none absolute inset-x-0 top-1/2 border-t border-base-300/70"
+        ></span>
+        <span
+          class="pointer-events-none absolute inset-x-0 top-3/4 border-t border-base-300/70"
+        ></span>
+        <div
+          class="relative flex h-full min-w-full items-end gap-px px-3 pb-8 pt-4"
+          [style.width.px]="chartWidth()"
+        >
+          @for (point of plottedPoints(); track point.day; let index = $index) {
+            <div class="relative flex h-full min-w-1 flex-1 items-end justify-center gap-px">
+              <span
+                class="w-1/2 min-w-1 rounded-t-field bg-base-content/25"
+                [style.height.%]="point.previousHeight"
+                [attr.title]="point.day + ' previous: ' + formatValue(point.previous)"
+              ></span>
+              <span
+                class="w-1/2 min-w-1 rounded-t-field bg-primary transition-colors hover:bg-primary/80"
+                [style.height.%]="point.currentHeight"
+                [attr.title]="point.day + ': ' + formatValue(point.current)"
+              ></span>
+              @if (showAxisLabel(index)) {
+                <span class="absolute -bottom-6 whitespace-nowrap text-xs text-base-content/60">
+                  {{ shortDay(point.day) }}
+                </span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class RestockTrendChartComponent {
+  readonly points = input.required<RestockTrendPoint[]>();
+  readonly metric = input<TrendMetric>('quantity');
+  protected readonly plottedPoints = computed(() => {
+    const source = this.points();
+    const values = source.flatMap(point =>
+      this.metric() === 'quantity'
+        ? [point.currentQuantity, point.previousQuantity]
+        : [point.currentRevenue, point.previousRevenue]
+    );
+    const maximum = Math.max(...values, 1);
+    return source.map(point => {
+      const current = this.metric() === 'quantity' ? point.currentQuantity : point.currentRevenue;
+      const previous =
+        this.metric() === 'quantity' ? point.previousQuantity : point.previousRevenue;
+      return {
+        day: point.day,
+        current,
+        previous,
+        currentHeight: current <= 0 ? 1 : Math.max(3, (current / maximum) * 100),
+        previousHeight: previous <= 0 ? 1 : Math.max(3, (previous / maximum) * 100),
+      };
+    });
+  });
+  protected readonly chartWidth = computed(() => Math.max(320, this.points().length * 8));
+  protected readonly peakLabel = computed(() => {
+    const maximum = Math.max(
+      ...this.points().flatMap(point =>
+        this.metric() === 'quantity'
+          ? [point.currentQuantity, point.previousQuantity]
+          : [point.currentRevenue, point.previousRevenue]
+      ),
+      0
+    );
+    return this.formatValue(maximum);
+  });
+  protected readonly ariaLabel = computed(
+    () =>
+      `${this.metric() === 'quantity' ? 'Units sold' : 'Sales value'} trend compared with the previous equal period`
+  );
+
+  protected formatValue(value: number): string {
+    if (this.metric() === 'quantity') {
+      return value.toLocaleString('en-KE', { maximumFractionDigits: 2 });
+    }
+    return new Intl.NumberFormat('en-KE', {
+      style: 'currency',
+      currency: 'KES',
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(value);
+  }
+
+  protected showAxisLabel(index: number): boolean {
+    const length = this.points().length;
+    if (index === 0 || index === length - 1) return true;
+    return index % Math.max(Math.ceil(length / 6), 1) === 0;
+  }
+
+  protected shortDay(day: string): string {
+    return new Intl.DateTimeFormat('en-KE', { day: 'numeric', month: 'short' }).format(
+      new Date(`${day}T00:00:00Z`)
+    );
+  }
+}

--- a/packages/shared-types/database.types.ts
+++ b/packages/shared-types/database.types.ts
@@ -3046,6 +3046,7 @@ export type Database = {
       dashboard_snapshot_cache: {
         Row: {
           as_of_date: string
+          catalog_sequence: number
           company_id: string
           computed_at: string
           range_days: number
@@ -3056,6 +3057,7 @@ export type Database = {
         }
         Insert: {
           as_of_date: string
+          catalog_sequence?: number
           company_id: string
           computed_at?: string
           range_days: number
@@ -3066,6 +3068,7 @@ export type Database = {
         }
         Update: {
           as_of_date?: string
+          catalog_sequence?: number
           company_id?: string
           computed_at?: string
           range_days?: number
@@ -11106,6 +11109,82 @@ export type Database = {
           },
         ]
       }
+      mv_daily_location_product_sales: {
+        Row: {
+          cogs: number | null
+          company_id: string | null
+          day: string | null
+          location_id: string | null
+          quantity: number | null
+          revenue: number | null
+          variant_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "order_lines_variant_id_fkey"
+            columns: ["variant_id"]
+            isOneToOne: false
+            referencedRelation: "low_stock_variants"
+            referencedColumns: ["variant_id"]
+          },
+          {
+            foreignKeyName: "order_lines_variant_id_fkey"
+            columns: ["variant_id"]
+            isOneToOne: false
+            referencedRelation: "low_stock_variants_by_location"
+            referencedColumns: ["variant_id"]
+          },
+          {
+            foreignKeyName: "order_lines_variant_id_fkey"
+            columns: ["variant_id"]
+            isOneToOne: false
+            referencedRelation: "product_stock"
+            referencedColumns: ["variant_id"]
+          },
+          {
+            foreignKeyName: "order_lines_variant_id_fkey"
+            columns: ["variant_id"]
+            isOneToOne: false
+            referencedRelation: "product_variants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "order_lines_variant_id_fkey"
+            columns: ["variant_id"]
+            isOneToOne: false
+            referencedRelation: "variant_catalog"
+            referencedColumns: ["variant_id"]
+          },
+          {
+            foreignKeyName: "orders_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "orders_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "public_storefronts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "orders_location_id_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "low_stock_variants_by_location"
+            referencedColumns: ["location_id"]
+          },
+          {
+            foreignKeyName: "orders_location_id_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "stock_locations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       mv_daily_order_stats: {
         Row: {
           company_id: string | null
@@ -14023,6 +14102,17 @@ export type Database = {
         }
         Returns: Json
       }
+      restock_product_intelligence: {
+        Args: {
+          p_limit?: number
+          p_location_id: string
+          p_manufacturer_id?: string
+          p_since: string
+          p_supplier_id?: string
+          p_until: string
+        }
+        Returns: Json
+      }
       prune_cache_change_log: { Args: never; Returns: number }
       public_billing_config: { Args: never; Returns: Json }
       public_blog_post: { Args: { p_slug: string }; Returns: Json }
@@ -15596,4 +15686,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/packages/shared-types/database.types.ts
+++ b/packages/shared-types/database.types.ts
@@ -14102,17 +14102,6 @@ export type Database = {
         }
         Returns: Json
       }
-      restock_product_intelligence: {
-        Args: {
-          p_limit?: number
-          p_location_id: string
-          p_manufacturer_id?: string
-          p_since: string
-          p_supplier_id?: string
-          p_until: string
-        }
-        Returns: Json
-      }
       prune_cache_change_log: { Args: never; Returns: number }
       public_billing_config: { Args: never; Returns: Json }
       public_blog_post: { Args: { p_slug: string }; Returns: Json }
@@ -14717,6 +14706,17 @@ export type Database = {
           p_requested_account_code?: string
         }
         Returns: string
+      }
+      restock_product_intelligence: {
+        Args: {
+          p_limit?: number
+          p_location_id: string
+          p_manufacturer_id?: string
+          p_since: string
+          p_supplier_id?: string
+          p_until: string
+        }
+        Returns: Json
       }
       retire_pos_device: {
         Args: { p_device_id: string; p_reason: string }
@@ -15686,3 +15686,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/supabase/migrations/20260822000000_0144_lean_product_intelligence.sql
+++ b/supabase/migrations/20260822000000_0144_lean_product_intelligence.sql
@@ -1,0 +1,247 @@
+-- Lean product intelligence: actionable dashboard signals.
+
+alter table public.dashboard_snapshot_cache
+  add column catalog_sequence bigint not null default 0;
+
+create or replace function public.dashboard_location_snapshot(
+  p_since date default ((now() at time zone 'Africa/Nairobi')::date - 6),
+  p_location_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_company_id uuid := public.current_company_id();
+  v_timezone text;
+  v_today date;
+  v_since date;
+  v_days integer;
+  v_previous_start timestamptz;
+  v_end timestamptz;
+  v_location_ids uuid[];
+  v_scope_key text;
+  v_sales_sequence bigint := 0;
+  v_settings_sequence bigint := 0;
+  v_catalog_sequence bigint := 0;
+  v_low_stock_threshold numeric := 0;
+  v_cached public.dashboard_snapshot_cache%rowtype;
+  v_has_lock boolean;
+  v_result jsonb;
+begin
+  if v_company_id is null then raise exception 'not_authenticated'; end if;
+  if not public.current_user_has_permission('ViewFinancials') then
+    raise exception 'permission_denied: ViewFinancials required';
+  end if;
+  if p_location_id is not null and not public.current_user_can_access_location(p_location_id) then
+    raise exception 'location_access_denied';
+  end if;
+
+  select company.business_timezone, company.low_stock_threshold
+  into v_timezone, v_low_stock_threshold
+  from public.companies company where company.id = v_company_id;
+  v_today := (now() at time zone v_timezone)::date;
+  v_since := coalesce(p_since, v_today - 6);
+  if v_since < v_today - 6 or v_since > v_today then
+    raise exception 'invalid_dashboard_range: dashboard supports at most 7 days';
+  end if;
+  v_days := greatest((v_today - v_since) + 1, 1);
+
+  if p_location_id is null then
+    select coalesce(array_agg(location.id order by location.id), '{}'::uuid[])
+    into v_location_ids
+    from public.accessible_business_locations() location;
+  else
+    v_location_ids := array[p_location_id];
+  end if;
+  v_scope_key := encode(
+    extensions.digest(convert_to(array_to_string(v_location_ids, ','), 'UTF8'), 'sha256'),
+    'hex'
+  );
+
+  select
+    coalesce(max(head_sequence) filter (where stream = 'sales'), 0),
+    coalesce(max(head_sequence) filter (where stream = 'settings'), 0),
+    coalesce(max(head_sequence) filter (where stream = 'catalog'), 0)
+  into v_sales_sequence, v_settings_sequence, v_catalog_sequence
+  from public.cache_stream_heads
+  where company_id = v_company_id
+    and stream in ('sales', 'settings', 'catalog');
+
+  select * into v_cached
+  from public.dashboard_snapshot_cache cache
+  where cache.company_id = v_company_id
+    and cache.scope_key = v_scope_key
+    and cache.range_days = v_days;
+
+  if found
+    and v_cached.as_of_date = v_today
+    and v_cached.sales_sequence = v_sales_sequence
+    and v_cached.settings_sequence = v_settings_sequence
+    and v_cached.catalog_sequence = v_catalog_sequence then
+    return v_cached.snapshot;
+  end if;
+  if found and v_cached.computed_at > clock_timestamp() - interval '60 seconds' then
+    return v_cached.snapshot || jsonb_build_object(
+      'refreshAfter', v_cached.computed_at + interval '60 seconds'
+    );
+  end if;
+
+  v_has_lock := pg_try_advisory_xact_lock(
+    hashtextextended(v_company_id::text || ':' || v_scope_key || ':' || v_since::text, 60)
+  );
+  if not v_has_lock and v_cached.snapshot is not null then
+    return v_cached.snapshot || jsonb_build_object(
+      'refreshAfter', clock_timestamp() + interval '2 seconds'
+    );
+  end if;
+  if not v_has_lock then
+    perform pg_advisory_xact_lock(
+      hashtextextended(v_company_id::text || ':' || v_scope_key || ':' || v_since::text, 60)
+    );
+    select * into v_cached
+    from public.dashboard_snapshot_cache cache
+    where cache.company_id = v_company_id
+      and cache.scope_key = v_scope_key
+      and cache.range_days = v_days;
+    if found
+      and v_cached.as_of_date = v_today
+      and v_cached.sales_sequence = v_sales_sequence
+      and v_cached.settings_sequence = v_settings_sequence
+      and v_cached.catalog_sequence = v_catalog_sequence then
+      return v_cached.snapshot;
+    end if;
+  end if;
+
+  v_previous_start := ((v_since - v_days)::timestamp at time zone v_timezone);
+  v_end := ((v_today + 1)::timestamp at time zone v_timezone);
+
+  with scoped_orders as materialized (
+    select
+      orders.id,
+      orders.location_id,
+      orders.total,
+      orders.cogs_total,
+      orders.quantity_total,
+      (orders.completed_at at time zone v_timezone)::date as day
+    from public.orders orders
+    where orders.company_id = v_company_id
+      and orders.status = 'completed'
+      and orders.completed_at >= v_previous_start
+      and orders.completed_at < v_end
+      and orders.location_id = any(v_location_ids)
+  ), current_orders as materialized (
+    select * from scoped_orders where day >= v_since
+  ), summary as (
+    select day, count(*)::integer as orders,
+      coalesce(sum(total), 0)::bigint as revenue,
+      coalesce(sum(cogs_total), 0)::bigint as cogs,
+      (coalesce(sum(total), 0) - coalesce(sum(cogs_total), 0))::bigint as margin,
+      coalesce(sum(quantity_total), 0) as quantity
+    from current_orders
+    group by day
+  ), variant_totals as materialized (
+    select line.variant_id,
+      coalesce(sum(line.quantity), 0) as quantity,
+      coalesce(sum(line.line_total), 0)::bigint as revenue,
+      coalesce(sum(round(
+        orders.cogs_total * line.line_total::numeric / nullif(orders.total, 0)
+      )), 0)::bigint as cogs
+    from current_orders orders
+    join public.order_lines line on line.order_id = orders.id
+    group by line.variant_id
+  ), tracked_variant_totals as materialized (
+    select totals.*
+    from variant_totals totals
+    join public.product_variants variant
+      on variant.id = totals.variant_id and variant.company_id = v_company_id
+    join public.products product
+      on product.id = variant.product_id and product.company_id = v_company_id
+    where variant.track_inventory and variant.kind <> 'service'
+      and variant.active and product.active
+  ), scoped_stock as materialized (
+    select batch.variant_id, coalesce(sum(batch.remaining), 0)::numeric as stock
+    from public.inventory_batches batch
+    where batch.company_id = v_company_id
+      and batch.stock_location_id = any(v_location_ids)
+      and batch.remaining > 0
+    group by batch.variant_id
+  ), top_variants as (
+    select variant_id, quantity, revenue, cogs, (revenue - cogs)::bigint as margin
+    from variant_totals
+    order by (revenue - cogs) desc, revenue desc, variant_id
+    limit 5
+  ), fast_variants as (
+    select variant_id, quantity, revenue, cogs, (revenue - cogs)::bigint as margin
+    from tracked_variant_totals
+    order by quantity desc, revenue desc, variant_id
+    limit 5
+  ), restock_risks as (
+    select totals.variant_id, totals.quantity,
+      coalesce(stock.stock, 0)::numeric as stock,
+      v_low_stock_threshold as low_stock_threshold
+    from tracked_variant_totals totals
+    left join scoped_stock stock on stock.variant_id = totals.variant_id
+    where totals.quantity > 0
+      and coalesce(stock.stock, 0) <= v_low_stock_threshold
+    order by totals.quantity desc, totals.revenue desc, totals.variant_id
+    limit 3
+  ), locations as (
+    select location.id as location_id, location.name as location_name,
+      count(orders.id)::integer as orders,
+      coalesce(sum(orders.total), 0)::bigint as revenue,
+      coalesce(sum(orders.quantity_total), 0) as quantity,
+      coalesce(sum(orders.cogs_total), 0)::bigint as cogs,
+      (coalesce(sum(orders.total), 0) - coalesce(sum(orders.cogs_total), 0))::bigint as margin
+    from public.stock_locations location
+    left join current_orders orders on orders.location_id = location.id
+    where location.company_id = v_company_id
+      and location.is_active
+      and location.id = any(v_location_ids)
+    group by location.id, location.name
+  ), comparison as (
+    select
+      coalesce(sum(total) filter (where day >= v_since), 0)::bigint as current_revenue,
+      coalesce(sum(quantity_total) filter (where day >= v_since), 0) as current_quantity,
+      count(*) filter (where day >= v_since)::integer as current_orders,
+      coalesce(sum(total) filter (where day < v_since), 0)::bigint as previous_revenue,
+      coalesce(sum(quantity_total) filter (where day < v_since), 0) as previous_quantity,
+      count(*) filter (where day < v_since)::integer as previous_orders
+    from scoped_orders
+  )
+  select jsonb_build_object(
+    'summary', coalesce((select jsonb_agg(to_jsonb(row) order by row.day) from summary row), '[]'::jsonb),
+    'topVariants', coalesce((select jsonb_agg(to_jsonb(row) order by row.margin desc, row.revenue desc) from top_variants row), '[]'::jsonb),
+    'productSignals', jsonb_build_object(
+      'restockRisks', coalesce((select jsonb_agg(to_jsonb(row) order by row.quantity desc) from restock_risks row), '[]'::jsonb),
+      'fastVariants', coalesce((select jsonb_agg(to_jsonb(row) order by row.quantity desc, row.revenue desc) from fast_variants row), '[]'::jsonb)
+    ),
+    'locations', coalesce((select jsonb_agg(to_jsonb(row) order by row.revenue desc, row.location_name) from locations row), '[]'::jsonb),
+    'comparison', coalesce((select to_jsonb(row) from comparison row), '{}'::jsonb)
+  ) into v_result;
+
+  insert into public.dashboard_snapshot_cache(
+    company_id, scope_key, range_days, as_of_date, sales_sequence,
+    settings_sequence, catalog_sequence, snapshot, computed_at
+  ) values (
+    v_company_id, v_scope_key, v_days, v_today, v_sales_sequence,
+    v_settings_sequence, v_catalog_sequence, v_result, clock_timestamp()
+  )
+  on conflict (company_id, scope_key, range_days) do update
+  set as_of_date = excluded.as_of_date,
+      sales_sequence = excluded.sales_sequence,
+      settings_sequence = excluded.settings_sequence,
+      catalog_sequence = excluded.catalog_sequence,
+      snapshot = excluded.snapshot,
+      computed_at = excluded.computed_at;
+
+  return v_result;
+end;
+$$;
+
+revoke execute on function public.dashboard_location_snapshot(date,uuid) from public, anon;
+grant execute on function public.dashboard_location_snapshot(date,uuid) to authenticated;
+
+comment on function public.dashboard_location_snapshot(date,uuid) is
+  'Returns compact live stats and product signals. Sales, settings, and catalog changes invalidate the lazy location-scoped cache.';

--- a/supabase/migrations/20260822000001_0145_restock_intelligence.sql
+++ b/supabase/migrations/20260822000001_0145_restock_intelligence.sql
@@ -1,0 +1,373 @@
+-- Location-aware restocking intelligence for supplier and manufacturer decisions.
+
+create materialized view public.mv_daily_location_product_sales as
+select
+  orders.company_id,
+  orders.location_id,
+  (orders.completed_at at time zone company.business_timezone)::date as day,
+  line.variant_id,
+  coalesce(sum(line.quantity), 0)::numeric as quantity,
+  coalesce(sum(line.line_total), 0)::bigint as revenue,
+  coalesce(sum(line.cogs_total), 0)::bigint as cogs
+from public.orders orders
+join public.companies company on company.id = orders.company_id
+join public.order_lines line on line.order_id = orders.id
+where orders.status = 'completed'
+  and orders.completed_at is not null
+  and orders.location_id is not null
+group by orders.company_id, orders.location_id,
+  (orders.completed_at at time zone company.business_timezone)::date,
+  line.variant_id;
+
+create unique index mv_daily_location_product_sales_idx
+  on public.mv_daily_location_product_sales(company_id, location_id, day, variant_id);
+create index mv_daily_location_product_sales_variant_day_idx
+  on public.mv_daily_location_product_sales(company_id, location_id, variant_id, day desc);
+
+revoke all on public.mv_daily_location_product_sales from public, anon, authenticated;
+
+create or replace function public.refresh_analytics()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  refresh materialized view concurrently public.mv_daily_sales_summary;
+  refresh materialized view concurrently public.mv_daily_product_sales;
+  refresh materialized view concurrently public.mv_daily_location_product_sales;
+  refresh materialized view concurrently public.mv_daily_customer_stats;
+  refresh materialized view concurrently public.mv_daily_order_stats;
+end;
+$$;
+
+revoke execute on function public.refresh_analytics() from authenticated, anon, public;
+grant execute on function public.refresh_analytics() to service_role;
+
+create or replace function public.restock_product_intelligence(
+  p_since date,
+  p_until date,
+  p_location_id uuid,
+  p_supplier_id uuid default null,
+  p_manufacturer_id uuid default null,
+  p_limit integer default 50
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_company_id uuid := public.current_company_id();
+  v_days integer;
+  v_previous_since date;
+  v_limit integer := least(greatest(coalesce(p_limit, 50), 1), 100);
+  v_low_stock_threshold numeric := 0;
+  v_result jsonb;
+begin
+  if v_company_id is null then raise exception 'not_authenticated'; end if;
+  if not public.current_user_has_permission('ViewFinancials') then
+    raise exception 'permission_denied: ViewFinancials required';
+  end if;
+  if p_since is null or p_until is null or p_since > p_until then
+    raise exception 'invalid_restock_intelligence_range';
+  end if;
+  v_days := (p_until - p_since) + 1;
+  if v_days > 366 then
+    raise exception 'restock_intelligence_range_too_large: maximum 366 days';
+  end if;
+  if p_location_id is null or not public.current_user_can_access_location(p_location_id) then
+    raise exception 'location_access_denied';
+  end if;
+  if (p_supplier_id is null) = (p_manufacturer_id is null) then
+    raise exception 'restock_scope_required: choose one supplier or manufacturer';
+  end if;
+  if p_supplier_id is not null and not exists (
+    select 1 from public.customers supplier
+    where supplier.id = p_supplier_id
+      and supplier.company_id = v_company_id
+      and supplier.is_supplier
+      and supplier.deleted_at is null
+  ) then
+    raise exception 'supplier_not_found';
+  end if;
+  if p_manufacturer_id is not null and not exists (
+    select 1 from public.manufacturers manufacturer
+    where manufacturer.id = p_manufacturer_id
+      and manufacturer.company_id = v_company_id
+  ) then
+    raise exception 'manufacturer_not_found';
+  end if;
+
+  select company.low_stock_threshold into v_low_stock_threshold
+  from public.companies company where company.id = v_company_id;
+  v_previous_since := p_since - v_days;
+
+  with candidate_variants as materialized (
+    select
+      variant.id as variant_id,
+      variant.product_id,
+      product.name as product_name,
+      variant.name as variant_name,
+      product.manufacturer_id,
+      manufacturer.name as manufacturer_name
+    from public.product_variants variant
+    join public.products product
+      on product.id = variant.product_id and product.company_id = variant.company_id
+    left join public.manufacturers manufacturer
+      on manufacturer.id = product.manufacturer_id
+     and manufacturer.company_id = product.company_id
+    where variant.company_id = v_company_id
+      and variant.active
+      and product.active
+      and variant.track_inventory
+      and variant.kind <> 'service'
+      and (p_manufacturer_id is null or product.manufacturer_id = p_manufacturer_id)
+      and (
+        p_supplier_id is null
+        or exists (
+          select 1
+          from public.inventory_batches batch
+          where batch.company_id = v_company_id
+            and batch.supplier_id = p_supplier_id
+            and batch.stock_location_id = p_location_id
+            and batch.variant_id = variant.id
+            and batch.remaining > 0
+        )
+        or exists (
+          select 1
+          from public.purchase_lines purchase_line
+          join public.purchases purchase
+            on purchase.id = purchase_line.purchase_id
+           and purchase.company_id = purchase_line.company_id
+          where purchase_line.company_id = v_company_id
+            and purchase_line.variant_id = variant.id
+            and purchase.supplier_id = p_supplier_id
+            and purchase.stock_location_id = p_location_id
+            and purchase.status = 'posted'
+        )
+      )
+  ), period_sales as materialized (
+    select
+      sale.variant_id,
+      coalesce(sum(sale.quantity) filter (where sale.day >= p_since), 0)::numeric
+        as current_quantity,
+      coalesce(sum(sale.revenue) filter (where sale.day >= p_since), 0)::bigint
+        as current_revenue,
+      coalesce(sum(sale.cogs) filter (where sale.day >= p_since), 0)::bigint
+        as current_cogs,
+      coalesce(sum(sale.quantity) filter (where sale.day < p_since), 0)::numeric
+        as previous_quantity,
+      coalesce(sum(sale.revenue) filter (where sale.day < p_since), 0)::bigint
+        as previous_revenue
+    from public.mv_daily_location_product_sales sale
+    join candidate_variants candidate on candidate.variant_id = sale.variant_id
+    where sale.company_id = v_company_id
+      and sale.location_id = p_location_id
+      and sale.day between v_previous_since and p_until
+    group by sale.variant_id
+  ), current_stock as materialized (
+    select
+      batch.variant_id,
+      coalesce(sum(batch.remaining), 0)::numeric as stock,
+      coalesce(sum(batch.remaining_cost), 0)::bigint as stock_value,
+      coalesce(sum(batch.remaining) filter (where batch.supplier_id = p_supplier_id), 0)::numeric
+        as supplier_stock
+    from public.inventory_batches batch
+    join candidate_variants candidate on candidate.variant_id = batch.variant_id
+    where batch.company_id = v_company_id
+      and batch.stock_location_id = p_location_id
+      and batch.remaining > 0
+    group by batch.variant_id
+  ), metrics as materialized (
+    select
+      candidate.*,
+      coalesce(sales.current_quantity, 0)::numeric as current_quantity,
+      coalesce(sales.current_revenue, 0)::bigint as current_revenue,
+      coalesce(sales.current_cogs, 0)::bigint as current_cogs,
+      (coalesce(sales.current_revenue, 0) - coalesce(sales.current_cogs, 0))::bigint
+        as current_margin,
+      coalesce(sales.previous_quantity, 0)::numeric as previous_quantity,
+      coalesce(sales.previous_revenue, 0)::bigint as previous_revenue,
+      coalesce(stock.stock, 0)::numeric as stock,
+      coalesce(stock.stock_value, 0)::bigint as stock_value,
+      coalesce(stock.supplier_stock, 0)::numeric as supplier_stock,
+      case when coalesce(sales.current_quantity, 0) > 0 then
+        coalesce(stock.stock, 0) / (sales.current_quantity / v_days)
+      end::numeric as days_cover
+    from candidate_variants candidate
+    left join period_sales sales on sales.variant_id = candidate.variant_id
+    left join current_stock stock on stock.variant_id = candidate.variant_id
+    where coalesce(stock.stock, 0) > 0
+       or coalesce(sales.current_quantity, 0) > 0
+       or coalesce(sales.previous_quantity, 0) > 0
+  ), ranked as materialized (
+    select metrics.*
+    from metrics
+    order by
+      case
+        when (current_quantity > 0 or previous_quantity > 0)
+          and stock <= v_low_stock_threshold then 0
+        when current_quantity > 0 and days_cover <= 14 then 1
+        when current_quantity > previous_quantity and days_cover <= 30 then 2
+        when current_quantity = 0 then 4
+        else 3
+      end,
+      current_quantity desc,
+      current_revenue desc,
+      variant_id
+    limit v_limit
+  ), latest_purchase as materialized (
+    select distinct on (purchase_line.variant_id)
+      purchase_line.variant_id,
+      purchase.supplier_id as last_supplier_id,
+      trim(concat_ws(' ', supplier.first_name, supplier.last_name)) as last_supplier_name,
+      purchase_line.unit_cost as last_unit_cost,
+      purchase.purchase_date as last_purchase_date
+    from public.purchase_lines purchase_line
+    join ranked product on product.variant_id = purchase_line.variant_id
+    join public.purchases purchase
+      on purchase.id = purchase_line.purchase_id
+     and purchase.company_id = purchase_line.company_id
+    join public.customers supplier
+      on supplier.id = purchase.supplier_id and supplier.company_id = purchase.company_id
+    where purchase_line.company_id = v_company_id
+      and purchase.stock_location_id = p_location_id
+      and purchase.status = 'posted'
+      and (p_supplier_id is null or purchase.supplier_id = p_supplier_id)
+    order by purchase_line.variant_id, purchase.purchase_date desc,
+      purchase.created_at desc, purchase_line.created_at desc
+  ), current_days as (
+    select generate_series(p_since, p_until, interval '1 day')::date as day
+  ), product_trends as (
+    select
+      ranked.variant_id,
+      jsonb_agg(coalesce(sale.quantity, 0) order by current_days.day) as quantities
+    from ranked
+    cross join current_days
+    left join public.mv_daily_location_product_sales sale
+      on sale.company_id = v_company_id
+     and sale.location_id = p_location_id
+     and sale.variant_id = ranked.variant_id
+     and sale.day = current_days.day
+    group by ranked.variant_id
+  ), overall_current as (
+    select
+      sale.day,
+      sum(sale.quantity)::numeric as quantity,
+      sum(sale.revenue)::bigint as revenue
+    from public.mv_daily_location_product_sales sale
+    join candidate_variants candidate on candidate.variant_id = sale.variant_id
+    where sale.company_id = v_company_id
+      and sale.location_id = p_location_id
+      and sale.day between p_since and p_until
+    group by sale.day
+  ), overall_previous as (
+    select
+      (sale.day + v_days)::date as day,
+      sum(sale.quantity)::numeric as quantity,
+      sum(sale.revenue)::bigint as revenue
+    from public.mv_daily_location_product_sales sale
+    join candidate_variants candidate on candidate.variant_id = sale.variant_id
+    where sale.company_id = v_company_id
+      and sale.location_id = p_location_id
+      and sale.day between v_previous_since and p_since - 1
+    group by sale.day
+  ), overall_trend as (
+    select
+      current_days.day,
+      coalesce(current_period.quantity, 0)::numeric as current_quantity,
+      coalesce(previous_period.quantity, 0)::numeric as previous_quantity,
+      coalesce(current_period.revenue, 0)::bigint as current_revenue,
+      coalesce(previous_period.revenue, 0)::bigint as previous_revenue
+    from current_days
+    left join overall_current current_period on current_period.day = current_days.day
+    left join overall_previous previous_period on previous_period.day = current_days.day
+  )
+  select jsonb_build_object(
+    'days', v_days,
+    'lowStockThreshold', v_low_stock_threshold,
+    'summary', jsonb_build_object(
+      'products', (select count(*) from metrics),
+      'unitsSold', coalesce((select sum(current_quantity) from metrics), 0),
+      'sales', coalesce((select sum(current_revenue) from metrics), 0),
+      'stock', coalesce((select sum(stock) from metrics), 0),
+      'stockValue', coalesce((select sum(stock_value) from metrics), 0),
+      'restockRisks', coalesce((select count(*) from metrics
+        where (current_quantity > 0 or previous_quantity > 0)
+          and (stock <= v_low_stock_threshold or days_cover <= 14)), 0)
+    ),
+    'trend', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'day', trend.day,
+        'currentQuantity', trend.current_quantity,
+        'previousQuantity', trend.previous_quantity,
+        'currentRevenue', trend.current_revenue,
+        'previousRevenue', trend.previous_revenue
+      ) order by trend.day)
+      from overall_trend trend
+    ), '[]'::jsonb),
+    'products', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'variantId', product.variant_id,
+        'productId', product.product_id,
+        'productName', product.product_name,
+        'variantName', product.variant_name,
+        'manufacturerId', product.manufacturer_id,
+        'manufacturerName', product.manufacturer_name,
+        'currentQuantity', product.current_quantity,
+        'currentRevenue', product.current_revenue,
+        'currentCogs', product.current_cogs,
+        'currentMargin', product.current_margin,
+        'previousQuantity', product.previous_quantity,
+        'previousRevenue', product.previous_revenue,
+        'stock', product.stock,
+        'stockValue', product.stock_value,
+        'supplierStock', product.supplier_stock,
+        'daysCover', product.days_cover,
+        'lastSupplierId', purchase.last_supplier_id,
+        'lastSupplierName', purchase.last_supplier_name,
+        'lastUnitCost', purchase.last_unit_cost,
+        'lastPurchaseDate', purchase.last_purchase_date,
+        'lastSoldOn', latest_sale.day,
+        'trend', product_trend.quantities
+      ) order by
+        case
+          when (product.current_quantity > 0 or product.previous_quantity > 0)
+            and product.stock <= v_low_stock_threshold then 0
+          when product.current_quantity > 0 and product.days_cover <= 14 then 1
+          when product.current_quantity > product.previous_quantity and product.days_cover <= 30 then 2
+          when product.current_quantity = 0 then 4
+          else 3
+        end,
+        product.current_quantity desc,
+        product.current_revenue desc,
+        product.variant_id)
+      from ranked product
+      join product_trends product_trend on product_trend.variant_id = product.variant_id
+      left join latest_purchase purchase on purchase.variant_id = product.variant_id
+      left join lateral (
+        select sale.day
+        from public.mv_daily_location_product_sales sale
+        where sale.company_id = v_company_id
+          and sale.location_id = p_location_id
+          and sale.variant_id = product.variant_id
+          and sale.day <= p_until
+        order by sale.day desc
+        limit 1
+      ) latest_sale on true
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+revoke execute on function public.restock_product_intelligence(date,date,uuid,uuid,uuid,integer)
+  from public, anon;
+grant execute on function public.restock_product_intelligence(date,date,uuid,uuid,uuid,integer)
+  to authenticated, service_role;
+
+comment on function public.restock_product_intelligence(date,date,uuid,uuid,uuid,integer) is
+  'Returns bounded location-aware sales trends, stock cover, and purchase context for one supplier or manufacturer.';

--- a/supabase/tests/database/0112_lean_product_intelligence.test.sql
+++ b/supabase/tests/database/0112_lean_product_intelligence.test.sql
@@ -1,0 +1,155 @@
+begin;
+select plan(4);
+
+select has_column(
+  'public', 'dashboard_snapshot_cache', 'catalog_sequence',
+  'dashboard cache records catalog changes'
+);
+
+select testkit.create_user(
+  '14440000-0000-4000-8000-000000000001', 'product-intelligence-admin@test.local');
+select testkit.create_user(
+  '14440000-0000-4000-8000-000000000002', 'product-intelligence-staff@test.local');
+create temp table intelligence_company as
+select testkit.provision(
+  '14440000-0000-4000-8000-000000000001', 'Product Intelligence Store'
+) company_id;
+grant select on pg_temp.intelligence_company to authenticated;
+select testkit.add_member(
+  (select company_id from intelligence_company),
+  '14440000-0000-4000-8000-000000000002',
+  'Product viewer', '{SettleOrder}'
+);
+
+insert into public.manufacturers(id, company_id, name)
+select '14440000-0000-4000-8000-000000000010', company_id, 'Acme'
+from intelligence_company;
+insert into public.categories(id, company_id, name, slug)
+select '14440000-0000-4000-8000-000000000011', company_id, 'Core stock', 'core-stock'
+from intelligence_company;
+
+insert into public.products(id, company_id, name, manufacturer_id)
+select '14440000-0000-4000-8000-000000000020', company_id, 'Tracked Tea',
+  '14440000-0000-4000-8000-000000000010'
+from intelligence_company;
+insert into public.products(id, company_id, name)
+select '14440000-0000-4000-8000-000000000021', company_id, 'Small Sale'
+from intelligence_company;
+insert into public.products(id, company_id, name)
+select '14440000-0000-4000-8000-000000000022', company_id, 'Stopped Sale'
+from intelligence_company;
+
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14440000-0000-4000-8000-000000000030',
+  '14440000-0000-4000-8000-000000000020', company_id,
+  'Default', 'INTEL-TEA', 1000, true
+from intelligence_company;
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14440000-0000-4000-8000-000000000031',
+  '14440000-0000-4000-8000-000000000021', company_id,
+  'Default', 'INTEL-SMALL', 500, false
+from intelligence_company;
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14440000-0000-4000-8000-000000000032',
+  '14440000-0000-4000-8000-000000000022', company_id,
+  'Default', 'INTEL-STOPPED', 800, false
+from intelligence_company;
+insert into public.product_categories(company_id, product_id, category_id)
+select company_id, '14440000-0000-4000-8000-000000000020',
+  '14440000-0000-4000-8000-000000000011'
+from intelligence_company;
+insert into public.inventory_batches(company_id, variant_id, quantity, remaining, unit_cost)
+select company_id, '14440000-0000-4000-8000-000000000030', 10, 10, 600
+from intelligence_company;
+
+select testkit.as_user(
+  (select company_id from intelligence_company),
+  '14440000-0000-4000-8000-000000000001', 'Admin'
+);
+select testkit.ensure_open_session();
+
+create temp table current_tea_sale as select public.post_sale(
+  null,
+  '[{"variant_id":"14440000-0000-4000-8000-000000000030","quantity":2,"unit_price":1000}]',
+  '[{"method":"cash","amount":2000}]'
+) order_id;
+create temp table current_small_sale as select public.post_sale(
+  null,
+  '[{"variant_id":"14440000-0000-4000-8000-000000000031","quantity":1,"unit_price":500}]',
+  '[{"method":"cash","amount":500}]'
+) order_id;
+create temp table previous_tea_sale as select public.post_sale(
+  null,
+  '[{"variant_id":"14440000-0000-4000-8000-000000000030","quantity":1,"unit_price":1000}]',
+  '[{"method":"cash","amount":1000}]'
+) order_id;
+create temp table previous_stopped_sale as select public.post_sale(
+  null,
+  '[{"variant_id":"14440000-0000-4000-8000-000000000032","quantity":3,"unit_price":800}]',
+  '[{"method":"cash","amount":2400}]'
+) order_id;
+grant select on pg_temp.current_tea_sale, pg_temp.current_small_sale,
+  pg_temp.previous_tea_sale, pg_temp.previous_stopped_sale to authenticated;
+
+reset role;
+update public.orders
+set created_at = ((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00',
+    completed_at = (((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00')
+      at time zone 'Africa/Nairobi'
+where id in (
+  (select order_id from previous_tea_sale),
+  (select order_id from previous_stopped_sale)
+);
+select public.refresh_analytics();
+
+select testkit.as_user(
+  (select company_id from intelligence_company),
+  '14440000-0000-4000-8000-000000000001', 'Admin'
+);
+
+create temp table intelligence_dashboard as
+select public.dashboard_location_snapshot() value;
+grant select on pg_temp.intelligence_dashboard to authenticated;
+select is(
+  (select value -> 'productSignals' -> 'restockRisks' -> 0 ->> 'variant_id'
+   from intelligence_dashboard),
+  '14440000-0000-4000-8000-000000000030',
+  'dashboard identifies a selling tracked variant below the stock threshold'
+);
+
+reset role;
+insert into public.inventory_batches(company_id, variant_id, quantity, remaining, unit_cost)
+select company_id, '14440000-0000-4000-8000-000000000030', 10, 10, 600
+from intelligence_company;
+select testkit.as_user(
+  (select company_id from intelligence_company),
+  '14440000-0000-4000-8000-000000000001', 'Admin'
+);
+select ok(
+  public.dashboard_location_snapshot() ? 'refreshAfter',
+  'stock changes invalidate the shared dashboard snapshot'
+);
+
+reset role;
+update public.dashboard_snapshot_cache
+set computed_at = clock_timestamp() - interval '61 seconds'
+where company_id = (select company_id from intelligence_company);
+select testkit.as_user(
+  (select company_id from intelligence_company),
+  '14440000-0000-4000-8000-000000000001', 'Admin'
+);
+select is(
+  jsonb_array_length(public.dashboard_location_snapshot()
+    -> 'productSignals' -> 'restockRisks'),
+  0,
+  'recomputed dashboard removes a restock risk after stock is received'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/0113_restock_intelligence.test.sql
+++ b/supabase/tests/database/0113_restock_intelligence.test.sql
@@ -1,0 +1,341 @@
+begin;
+select plan(14);
+
+select ok(
+  to_regclass('public.mv_daily_location_product_sales') is not null,
+  'location product sales rollup exists'
+);
+select has_function(
+  'public', 'restock_product_intelligence',
+  array['date','date','uuid','uuid','uuid','integer'],
+  'bounded restock intelligence RPC exists'
+);
+
+select testkit.create_user(
+  '14550000-0000-4000-8000-000000000001', 'restock-admin@test.local');
+select testkit.create_user(
+  '14550000-0000-4000-8000-000000000002', 'restock-staff@test.local');
+create temp table restock_company as
+select testkit.provision(
+  '14550000-0000-4000-8000-000000000001', 'Restock Intelligence Store'
+) company_id;
+grant select on pg_temp.restock_company to authenticated;
+select testkit.add_member(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000002',
+  'Stock viewer', '{SettleOrder}'
+);
+
+update public.companies set low_stock_threshold = 6
+where id = (select company_id from restock_company);
+
+create temp table restock_locations as
+select id as main_id, null::uuid as other_id
+from public.stock_locations
+where company_id = (select company_id from restock_company)
+  and is_default
+limit 1;
+update restock_locations set other_id = '14550000-0000-4000-8000-000000000009';
+grant select on pg_temp.restock_locations to authenticated;
+insert into public.stock_locations(
+  id, company_id, code, name, is_active, is_default
+)
+select other_id, company_id, 'OTHER', 'Other branch', true, false
+from restock_locations cross join restock_company;
+
+insert into public.customers(id, company_id, first_name, is_supplier)
+select '14550000-0000-4000-8000-000000000010', company_id, 'Fresh Supply', true
+from restock_company;
+insert into public.customers(id, company_id, first_name, is_supplier)
+select '14550000-0000-4000-8000-000000000011', company_id, 'Alternate Supply', true
+from restock_company;
+insert into public.manufacturers(id, company_id, name)
+select '14550000-0000-4000-8000-000000000012', company_id, 'Acme Foods'
+from restock_company;
+insert into public.manufacturers(id, company_id, name)
+select '14550000-0000-4000-8000-000000000013', company_id, 'Other Foods'
+from restock_company;
+
+insert into public.products(id, company_id, name, manufacturer_id)
+select '14550000-0000-4000-8000-000000000020', company_id, 'Restock Tea',
+  '14550000-0000-4000-8000-000000000012'
+from restock_company;
+insert into public.products(id, company_id, name, manufacturer_id)
+select '14550000-0000-4000-8000-000000000021', company_id, 'Restock Sugar',
+  '14550000-0000-4000-8000-000000000012'
+from restock_company;
+insert into public.products(id, company_id, name, manufacturer_id)
+select '14550000-0000-4000-8000-000000000022', company_id, 'Other Flour',
+  '14550000-0000-4000-8000-000000000013'
+from restock_company;
+insert into public.products(id, company_id, name, manufacturer_id)
+select '14550000-0000-4000-8000-000000000023', company_id, 'Delivery Service',
+  '14550000-0000-4000-8000-000000000012'
+from restock_company;
+
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14550000-0000-4000-8000-000000000030',
+  '14550000-0000-4000-8000-000000000020', company_id,
+  'Default', 'RESTOCK-TEA', 1000, true
+from restock_company;
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14550000-0000-4000-8000-000000000031',
+  '14550000-0000-4000-8000-000000000021', company_id,
+  'Default', 'RESTOCK-SUGAR', 500, true
+from restock_company;
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory
+)
+select '14550000-0000-4000-8000-000000000032',
+  '14550000-0000-4000-8000-000000000022', company_id,
+  'Default', 'RESTOCK-FLOUR', 700, true
+from restock_company;
+insert into public.product_variants(
+  id, product_id, company_id, name, sku, price, track_inventory, kind
+)
+select '14550000-0000-4000-8000-000000000033',
+  '14550000-0000-4000-8000-000000000023', company_id,
+  'Default', 'RESTOCK-SERVICE', 200, false, 'service'
+from restock_company;
+
+insert into public.inventory_batches(
+  id, company_id, variant_id, stock_location_id, supplier_id, quantity, remaining, unit_cost
+)
+select '14550000-0000-4000-8000-000000000040', company_id,
+  '14550000-0000-4000-8000-000000000030', main_id,
+  '14550000-0000-4000-8000-000000000010', 12, 12, 600
+from restock_company cross join restock_locations;
+insert into public.inventory_batches(
+  id, company_id, variant_id, stock_location_id, supplier_id, quantity, remaining, unit_cost
+)
+select '14550000-0000-4000-8000-000000000041', company_id,
+  '14550000-0000-4000-8000-000000000030', main_id,
+  '14550000-0000-4000-8000-000000000011', 10, 10, 650
+from restock_company cross join restock_locations;
+insert into public.inventory_batches(
+  id, company_id, variant_id, stock_location_id, supplier_id, quantity, remaining, unit_cost
+)
+select '14550000-0000-4000-8000-000000000042', company_id,
+  '14550000-0000-4000-8000-000000000031', main_id,
+  '14550000-0000-4000-8000-000000000010', 8, 8, 300
+from restock_company cross join restock_locations;
+insert into public.inventory_batches(
+  id, company_id, variant_id, stock_location_id, supplier_id, quantity, remaining, unit_cost
+)
+select '14550000-0000-4000-8000-000000000043', company_id,
+  '14550000-0000-4000-8000-000000000030', other_id,
+  '14550000-0000-4000-8000-000000000010', 50, 50, 590
+from restock_company cross join restock_locations;
+insert into public.inventory_batches(
+  id, company_id, variant_id, stock_location_id, supplier_id, quantity, remaining, unit_cost
+)
+select '14550000-0000-4000-8000-000000000044', company_id,
+  '14550000-0000-4000-8000-000000000032', main_id,
+  '14550000-0000-4000-8000-000000000011', 20, 20, 400
+from restock_company cross join restock_locations;
+
+select testkit.as_user(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000001', 'Admin'
+);
+reset role;
+insert into public.purchases(
+  id, company_id, supplier_id, stock_location_id, total_cost, status, purchase_date
+)
+select '14550000-0000-4000-8000-000000000050', company_id,
+  '14550000-0000-4000-8000-000000000010', main_id,
+  9600, 'posted', current_date - 14
+from restock_company cross join restock_locations;
+insert into public.purchase_lines(
+  company_id, purchase_id, variant_id, inventory_batch_id, quantity, unit_cost, line_total
+)
+select company_id, '14550000-0000-4000-8000-000000000050',
+  '14550000-0000-4000-8000-000000000030',
+  '14550000-0000-4000-8000-000000000040', 12, 600, 7200
+from restock_company;
+insert into public.purchase_lines(
+  company_id, purchase_id, variant_id, inventory_batch_id, quantity, unit_cost, line_total
+)
+select company_id, '14550000-0000-4000-8000-000000000050',
+  '14550000-0000-4000-8000-000000000031',
+  '14550000-0000-4000-8000-000000000042', 8, 300, 2400
+from restock_company;
+insert into public.purchase_lines(
+  company_id, purchase_id, variant_id, quantity, unit_cost, line_total
+)
+select company_id, '14550000-0000-4000-8000-000000000050',
+  '14550000-0000-4000-8000-000000000033', 1, 200, 200
+from restock_company;
+
+select testkit.as_user(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000001', 'Admin'
+);
+select testkit.ensure_open_session();
+
+create temp table current_tea as select public.post_sale(
+  null,
+  '[{"variant_id":"14550000-0000-4000-8000-000000000030","quantity":4,"unit_price":1000}]',
+  '[{"method":"cash","amount":4000}]'
+) order_id;
+create temp table current_sugar as select public.post_sale(
+  null,
+  '[{"variant_id":"14550000-0000-4000-8000-000000000031","quantity":2,"unit_price":500}]',
+  '[{"method":"cash","amount":1000}]'
+) order_id;
+create temp table previous_tea as select public.post_sale(
+  null,
+  '[{"variant_id":"14550000-0000-4000-8000-000000000030","quantity":2,"unit_price":1000}]',
+  '[{"method":"cash","amount":2000}]'
+) order_id;
+create temp table previous_sugar as select public.post_sale(
+  null,
+  '[{"variant_id":"14550000-0000-4000-8000-000000000031","quantity":4,"unit_price":500}]',
+  '[{"method":"cash","amount":2000}]'
+) order_id;
+select public.post_sale(
+  null,
+  '[{"variant_id":"14550000-0000-4000-8000-000000000030","quantity":1,"unit_price":1000}]',
+  '[]', true
+);
+grant select on pg_temp.current_tea, pg_temp.current_sugar,
+  pg_temp.previous_tea, pg_temp.previous_sugar to authenticated;
+
+reset role;
+update public.orders
+set created_at = ((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00',
+    completed_at = (((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00')
+      at time zone 'Africa/Nairobi'
+where id in ((select order_id from previous_tea), (select order_id from previous_sugar));
+select public.refresh_analytics();
+
+select testkit.as_user(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000001', 'Admin'
+);
+create temp table supplier_restock_report as
+select public.restock_product_intelligence(
+  (now() at time zone 'Africa/Nairobi')::date - 6,
+  (now() at time zone 'Africa/Nairobi')::date,
+  (select main_id from restock_locations),
+  '14550000-0000-4000-8000-000000000010', null, 50
+) value;
+grant select on pg_temp.supplier_restock_report to authenticated;
+
+select results_eq(
+  $$select item ->> 'variantId'
+    from supplier_restock_report,
+      jsonb_array_elements(value -> 'products') item
+    order by item ->> 'variantId'$$,
+  $$values
+    ('14550000-0000-4000-8000-000000000030'::text),
+    ('14550000-0000-4000-8000-000000000031'::text)$$,
+  'supplier scope includes its goods and excludes other suppliers and services'
+);
+select is(
+  ((select value from supplier_restock_report) -> 'summary' ->> 'unitsSold')::numeric,
+  6::numeric,
+  'current totals count only completed sales'
+);
+select is(
+  (select sum((point ->> 'previousQuantity')::numeric)
+   from supplier_restock_report, jsonb_array_elements(value -> 'trend') point),
+  6::numeric,
+  'trend includes the previous equal period'
+);
+select is(
+  jsonb_array_length((select value -> 'trend' from supplier_restock_report)),
+  7,
+  'trend returns one point for every selected day'
+);
+select results_eq(
+  $$select (item ->> 'stock')::numeric, (item ->> 'supplierStock')::numeric
+    from supplier_restock_report, jsonb_array_elements(value -> 'products') item
+    where item ->> 'variantId' = '14550000-0000-4000-8000-000000000030'$$,
+  $$values (16::numeric, 6::numeric)$$,
+  'stock uses the selected location and separates total from supplier-sourced stock'
+);
+select is(
+  ((select value from supplier_restock_report) -> 'summary' ->> 'restockRisks')::integer,
+  1,
+  'short stock is counted as a restock risk'
+);
+select results_eq(
+  $$select (item ->> 'lastUnitCost')::bigint, (item ->> 'lastPurchaseDate')::date
+    from supplier_restock_report, jsonb_array_elements(value -> 'products') item
+    where item ->> 'variantId' = '14550000-0000-4000-8000-000000000030'$$,
+  $$values (600::bigint, current_date - 14)$$,
+  'latest supplier cost and receipt date are returned'
+);
+select is(
+  jsonb_array_length(public.restock_product_intelligence(
+    (now() at time zone 'Africa/Nairobi')::date - 6,
+    (now() at time zone 'Africa/Nairobi')::date,
+    (select main_id from restock_locations), null,
+    '14550000-0000-4000-8000-000000000012', 50
+  ) -> 'products'),
+  2,
+  'manufacturer scope returns stocked goods from the selected manufacturer'
+);
+
+reset role;
+update public.orders
+set created_at = ((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00',
+    completed_at = (((now() at time zone 'Africa/Nairobi')::date - 7) + time '12:00')
+      at time zone 'Africa/Nairobi'
+where id = (select order_id from current_sugar);
+update public.inventory_batches
+set remaining = 0, remaining_cost = 0
+where id = '14550000-0000-4000-8000-000000000042';
+select public.refresh_analytics();
+select testkit.as_user(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000001', 'Admin'
+);
+select is(
+  (public.restock_product_intelligence(
+    (now() at time zone 'Africa/Nairobi')::date - 6,
+    (now() at time zone 'Africa/Nairobi')::date,
+    (select main_id from restock_locations),
+    '14550000-0000-4000-8000-000000000010', null, 50
+  ) -> 'summary' ->> 'restockRisks')::integer,
+  1,
+  'a sold-out product with previous-period demand remains a restock risk'
+);
+select throws_ok(
+  $$select public.restock_product_intelligence(
+    current_date-400,current_date,
+    (select main_id from restock_locations),
+    '14550000-0000-4000-8000-000000000010',null,50
+  )$$,
+  'P0001', 'restock_intelligence_range_too_large: maximum 366 days',
+  'restock intelligence rejects unbounded ranges'
+);
+select throws_ok(
+  $$select public.restock_product_intelligence(
+    current_date-6,current_date,
+    (select main_id from restock_locations),null,null,50
+  )$$,
+  'P0001', 'restock_scope_required: choose one supplier or manufacturer',
+  'restock intelligence requires one product source'
+);
+select testkit.as_user(
+  (select company_id from restock_company),
+  '14550000-0000-4000-8000-000000000002', 'Stock viewer'
+);
+select throws_ok(
+  $$select public.restock_product_intelligence(
+    current_date-6,current_date,
+    (select main_id from restock_locations),
+    '14550000-0000-4000-8000-000000000010',null,50
+  )$$,
+  'P0001', 'permission_denied: ViewFinancials required',
+  'restock intelligence requires financial permission'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
- Create a materialized view for daily location product sales to support restocking decisions.
- Implement the `refresh_analytics` function to refresh relevant materialized views.
- Develop the `restock_product_intelligence` function to provide insights on stock levels and sales trends for specific suppliers or manufacturers.
- Add tests for the new restocking intelligence functionality, ensuring proper permissions and data integrity.
- Create test cases for various scenarios including stock levels, sales trends, and permission checks.